### PR TITLE
wip: Add DirectWrite font provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,7 +615,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 1.0.63",
- "windows",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -1689,6 +1689,8 @@ dependencies = [
  "text-sys",
  "thiserror 1.0.63",
  "wgpu",
+ "windows 0.61.1",
+ "windows-core 0.61.0",
 ]
 
 [[package]]
@@ -2082,8 +2084,8 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
- "windows",
- "windows-core",
+ "windows 0.58.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -2113,8 +2115,30 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
- "windows-core",
+ "windows-core 0.58.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.0",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.0",
 ]
 
 [[package]]
@@ -2123,11 +2147,34 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
- "windows-strings",
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+dependencies = [
+ "windows-implement 0.60.0",
+ "windows-interface 0.59.1",
+ "windows-link",
+ "windows-result 0.3.2",
+ "windows-strings 0.4.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1d6bbefcb7b60acd19828e1bc965da6fcf18a7e39490c5f8be71e54a19ba32"
+dependencies = [
+ "windows-core 0.61.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -2135,6 +2182,17 @@ name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2153,6 +2211,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.0",
+ "windows-link",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2162,13 +2247,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ wgpu = { version = "24", optional = true }
 
 icu_segmenter = { version = "1", features = ["compiled_data"] }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.61", features = ["Win32_Graphics_DirectWrite"] }
+windows-core = "0.61"
+
 [profile.release]
 panic = "abort"
 

--- a/src/text/font_match.rs
+++ b/src/text/font_match.rs
@@ -2,7 +2,7 @@ use std::cmp::Reverse;
 
 use crate::{math::I16Dot16, I26Dot6};
 
-use super::{font_db, Face, FaceInfo, Font, FontArena, FontDb, FontStyle};
+use super::{font_db, Face, FaceInfo, Font, FontArena, FontDb, FontFallbackRequest, FontStyle};
 
 // This function actually implements the logic from level 4
 // https://drafts.csswg.org/css-fonts/#font-style-matching
@@ -234,10 +234,10 @@ impl<'a, 'f> FontMatchIterator<'a, 'f> {
                     self.index += 1;
                 }
 
-                match fonts.select(&super::FontRequest {
+                match fonts.select_fallback(&FontFallbackRequest {
                     families: self.matcher.families.clone(),
                     style: self.matcher.style,
-                    codepoint: Some(codepoint),
+                    codepoint,
                 }) {
                     Ok(face) => Ok(Some(
                         arena.insert(&face.with_size(self.matcher.size, self.matcher.dpi)?),

--- a/src/text/font_provider/directwrite.rs
+++ b/src/text/font_provider/directwrite.rs
@@ -1,0 +1,323 @@
+use std::hash::Hash;
+use std::sync::Arc;
+
+use windows::core::{implement, Interface, PCWSTR};
+use windows::Win32::Graphics::DirectWrite::{
+    DWriteCreateFactory, IDWriteFactory, IDWriteFactory2, IDWriteFont, IDWriteFontCollection,
+    IDWriteFontFallback, IDWriteFontFamily, IDWriteFontFile, IDWriteTextAnalysisSource,
+    IDWriteTextAnalysisSource_Impl, DWRITE_FACTORY_TYPE_ISOLATED, DWRITE_FONT_STRETCH_NORMAL,
+    DWRITE_FONT_STYLE_ITALIC, DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_WEIGHT,
+    DWRITE_READING_DIRECTION_LEFT_TO_RIGHT,
+};
+use windows_core::BOOL;
+
+use crate::math::I16Dot16;
+use crate::text::font_db::FontProvider;
+use crate::text::{Face, FaceInfo, LoadError};
+
+impl super::super::Sealed for DirectWriteFontProvider {}
+
+fn codepoint_to_utf16(mut value: u32) -> ([u16; 2], bool) {
+    if value < 0x10000 {
+        ([value as u16, 0], false)
+    } else {
+        value -= 0x10000;
+        (
+            [
+                (((value & 0b1111_1111_1100_0000_0000) >> 10) + 0xD800) as u16,
+                ((value & 0b0000_0000_0011_1111_1111) + 0xDC00) as u16,
+            ],
+            true,
+        )
+    }
+}
+
+#[implement(IDWriteTextAnalysisSource)]
+struct TextAnalysisSource {
+    text: [u16; 2],
+    len: bool,
+}
+
+impl IDWriteTextAnalysisSource_Impl for TextAnalysisSource_Impl {
+    fn GetTextAtPosition(
+        &self,
+        textposition: u32,
+        textstring: *mut *mut u16,
+        textlength: *mut u32,
+    ) -> windows::core::Result<()> {
+        unsafe {
+            let Some(result) = self.text.get(textposition as usize..self.len as usize + 1) else {
+                *textstring = std::ptr::null_mut();
+                *textlength = 0;
+                return Ok(());
+            };
+
+            *textstring = result.as_ptr().cast_mut();
+            *textlength = result.len() as u32;
+
+            Ok(())
+        }
+    }
+
+    fn GetTextBeforePosition(
+        &self,
+        textposition: u32,
+        textstring: *mut *mut u16,
+        textlength: *mut u32,
+    ) -> windows::core::Result<()> {
+        unsafe {
+            let Some(result) = self.text[..self.len as usize + 1]
+                .get(..textposition as usize)
+                .filter(|s| !s.is_empty())
+            else {
+                *textstring = std::ptr::null_mut();
+                *textlength = 0;
+                return Ok(());
+            };
+
+            *textstring = result.as_ptr().cast_mut();
+            *textlength = result.len() as u32;
+
+            Ok(())
+        }
+    }
+
+    fn GetParagraphReadingDirection(
+        &self,
+    ) -> windows::Win32::Graphics::DirectWrite::DWRITE_READING_DIRECTION {
+        DWRITE_READING_DIRECTION_LEFT_TO_RIGHT
+    }
+
+    fn GetLocaleName(
+        &self,
+        textposition: u32,
+        textlength: *mut u32,
+        localename: *mut *mut u16,
+    ) -> windows::core::Result<()> {
+        unsafe {
+            *textlength = (self.len as u32 + 1).saturating_sub(textposition);
+            *localename = windows_core::w!("").as_ptr().cast_mut();
+
+            Ok(())
+        }
+    }
+
+    fn GetNumberSubstitution(
+        &self,
+        _textposition: u32,
+        textlength: *mut u32,
+        numbersubstitution: windows::core::OutRef<
+            '_,
+            windows::Win32::Graphics::DirectWrite::IDWriteNumberSubstitution,
+        >,
+    ) -> windows::core::Result<()> {
+        unsafe {
+            textlength.write(0);
+            numbersubstitution.write(None)?;
+            Ok(())
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Source {
+    file: IDWriteFontFile,
+    index: u32,
+}
+
+// TODO: Don't cache DWrite sources
+impl Hash for Source {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.file.as_raw().hash(state);
+    }
+}
+
+impl Source {
+    fn get_data(&self) -> Result<Arc<[u8]>, windows::core::Error> {
+        unsafe {
+            let mut reference_key = std::ptr::null_mut();
+            let mut reference_key_size = 0;
+            self.file
+                .GetReferenceKey(&mut reference_key, &mut reference_key_size)?;
+            let loader = self.file.GetLoader()?;
+            let stream = loader.CreateStreamFromKey(reference_key, reference_key_size)?;
+            let size = stream.GetFileSize()?;
+            let mut output = Vec::new();
+            output.reserve(size as usize);
+            let mut context = std::ptr::null_mut();
+            let mut data = std::ptr::null_mut();
+            stream.ReadFileFragment(&mut data, 0, size, &mut context)?;
+            output.extend_from_slice(std::slice::from_raw_parts(data as *const u8, size as usize));
+            stream.ReleaseFileFragment(context);
+            output.set_len(size as usize);
+            Ok(output.into())
+        }
+    }
+
+    pub fn open(&self) -> Result<Face, LoadError> {
+        Ok(Face::load_from_bytes(
+            self.get_data().map_err(LoadError::DirectWrite)?,
+            self.index as i32,
+        )?)
+    }
+}
+
+#[derive(Debug)]
+pub struct DirectWriteFontProvider {
+    font_collection: IDWriteFontCollection,
+    fallback: IDWriteFontFallback,
+}
+
+impl DirectWriteFontProvider {
+    pub fn new() -> Result<Self, windows::core::Error> {
+        unsafe {
+            let factory: IDWriteFactory = DWriteCreateFactory(DWRITE_FACTORY_TYPE_ISOLATED)?;
+            let mut font_collection = None;
+            factory.GetSystemFontCollection(&mut font_collection, false)?;
+            let font_collection = font_collection.unwrap();
+
+            Ok(Self {
+                font_collection,
+                fallback: factory.cast::<IDWriteFactory2>()?.GetSystemFontFallback()?,
+            })
+        }
+    }
+
+    fn info_from_font(font: IDWriteFont) -> Result<Option<FaceInfo>, windows::core::Error> {
+        unsafe {
+            let weight = font.GetWeight();
+            let style = font.GetStyle();
+
+            let face = font.CreateFontFace()?;
+            let mut n_files = 0;
+            face.GetFiles(&mut n_files, None)?;
+
+            let mut files: Vec<IDWriteFontFile> = Vec::new();
+            files.reserve(n_files as usize);
+            face.GetFiles(
+                &mut n_files,
+                Some(files.spare_capacity_mut().as_mut_ptr().cast()),
+            )?;
+            files.set_len(n_files as usize);
+
+            let source = if let Some(file) = files.drain(..1).next() {
+                Source {
+                    file,
+                    index: face.GetIndex(),
+                }
+            } else {
+                return Ok(None);
+            };
+
+            let names = font.GetFontFamily()?.GetFamilyNames()?;
+            let mut name_buffer = vec![0u16; names.GetStringLength(0)? as usize + 1];
+            names.GetString(0, &mut name_buffer)?;
+
+            Ok(Some(FaceInfo {
+                family: match String::from_utf16(&name_buffer) {
+                    Ok(name) => name.into(),
+                    // TODO: Return an error
+                    Err(_) => return Ok(None),
+                },
+                // TODO: Width conversion
+                width: crate::text::FontAxisValues::Fixed(I16Dot16::new(100)),
+                weight: crate::text::FontAxisValues::Fixed(I16Dot16::new(weight.0)),
+                italic: style == DWRITE_FONT_STYLE_ITALIC,
+                source: crate::text::FontSource::DirectWrite(source),
+            }))
+        }
+    }
+
+    fn gather_fonts_from_family(
+        result: &mut Vec<FaceInfo>,
+        set: IDWriteFontFamily,
+    ) -> Result<(), windows::core::Error> {
+        unsafe {
+            let n = set.GetFontCount();
+            for i in 0..n {
+                result.extend(Self::info_from_font(set.GetFont(i)?)?)
+            }
+
+            Ok(())
+        }
+    }
+}
+
+impl FontProvider for DirectWriteFontProvider {
+    fn query_fallback(
+        &mut self,
+        request: &crate::text::FontFallbackRequest,
+    ) -> Result<Vec<crate::text::FaceInfo>, crate::util::AnyError> {
+        unsafe {
+            let (utf16, len) = codepoint_to_utf16(request.codepoint);
+            let source = TextAnalysisSource { text: utf16, len };
+
+            let family_w: Option<Vec<u16>> = request.families.get(0).map(|f| {
+                f.encode_utf16()
+                    .chain(std::iter::once(0))
+                    .collect::<Vec<_>>()
+            });
+
+            let mut mapped_len = 0;
+            let mut mapped_font = None;
+            let mut scale = 0.0;
+            self.fallback.MapCharacters(
+                &IDWriteTextAnalysisSource::from(source),
+                0,
+                len as u32 + 1,
+                None,
+                family_w
+                    .as_ref()
+                    .map(|f| PCWSTR::from_raw(f.as_ptr()))
+                    .unwrap_or(PCWSTR::null()),
+                DWRITE_FONT_WEIGHT(request.style.weight.round_to_inner()),
+                if request.style.italic {
+                    DWRITE_FONT_STYLE_ITALIC
+                } else {
+                    DWRITE_FONT_STYLE_NORMAL
+                },
+                DWRITE_FONT_STRETCH_NORMAL,
+                &mut mapped_len,
+                &mut mapped_font,
+                &mut scale,
+            )?;
+
+            return Ok(match mapped_font {
+                Some(font) => match Self::info_from_font(font)? {
+                    Some(info) => vec![info],
+                    None => Vec::new(),
+                },
+                None => Vec::new(),
+            });
+        }
+    }
+
+    fn query_family(
+        &mut self,
+        family: &str,
+    ) -> Result<Vec<crate::text::FaceInfo>, crate::util::AnyError> {
+        let mut result = Vec::new();
+
+        unsafe {
+            let family_w = family
+                .encode_utf16()
+                .chain(std::iter::once(0))
+                .collect::<Vec<_>>();
+            let mut family_index = 0;
+            let mut family_exists = BOOL(0);
+            self.font_collection.FindFamilyName(
+                PCWSTR::from_raw(family_w.as_ptr()),
+                &mut family_index,
+                &mut family_exists,
+            )?;
+            if !family_exists.as_bool() {
+                return Ok(result);
+            }
+            let dwrite_family = self.font_collection.GetFontFamily(family_index)?;
+
+            Self::gather_fonts_from_family(&mut result, dwrite_family)?;
+        }
+
+        Ok(result)
+    }
+}

--- a/text-sys/build.rs
+++ b/text-sys/build.rs
@@ -1,9 +1,7 @@
 fn main() {
     println!("cargo:rustc-link-lib=freetype");
     println!("cargo:rustc-link-lib=harfbuzz");
-    if std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap() == "unix"
-        || std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "windows"
-    {
+    if std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap() == "unix" {
         println!("cargo:rustc-link-lib=fontconfig");
     }
 

--- a/text-sys/generate_bindings.sh
+++ b/text-sys/generate_bindings.sh
@@ -18,7 +18,7 @@ bindgen \
 	--raw-line '#![allow(non_camel_case_types)]' \
 	--raw-line '#![allow(non_snake_case)]' \
 	--raw-line '#![allow(improper_ctypes)]' \
-	--raw-line '#[cfg(any(target_family = "unix", target_os = "windows"))]' \
+	--raw-line '#[cfg(target_family = "unix")]' \
 	--raw-line 'pub mod fontconfig;' \
 	--no-prepend-enum-name \
 	--no-layout-tests \

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -46,9 +46,14 @@ fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
 fn make_pkgconfig_file(prefix: &Path, version: &str, target: &str) -> String {
     let prefix_str = prefix.to_str().unwrap().trim_end_matches('/');
     let extra_link_flags = if target.contains("-windows-") {
-        "-lWs2_32 -lNtosKrnl -luserenv"
+        "-lWs2_32 -lUserenv"
     } else {
         ""
+    };
+    let extra_requires = if target.contains("-windows-") {
+        ""
+    } else {
+        ", fontconfig >= 2"
     };
 
     format!(
@@ -59,7 +64,7 @@ includedir={prefix_str}/include
 Name: subrandr
 Description: A subtitle rendering library
 Version: {version}
-Requires: freetype2 >= 26, harfbuzz >= 10, fontconfig >= 2
+Requires: freetype2 >= 26, harfbuzz >= 10{extra_requires}
 Cflags: -I${{includedir}}
 Libs: -L${{libdir}} -lsubrandr {extra_link_flags}
 "#


### PR DESCRIPTION
Work-in-progress DirectWrite font provider.
I tried using fontconfig on Windows and encountered a segmentation fault somewhere in fontconfig, and decided it would be better to just add that DirectWrite font provider.

This implementation is not ready yet, fallback font selection is not implemented yet and a dirty hack is used to propagate errors in `FontSource::load`.