### PR TITLE
Implement ABI versioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,6 +391,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,6 +784,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e52775179941363cc594e49ce99284d13d6948928d8e72c755f55e98caa1eb"
 
 [[package]]
+name = "implib"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598bf7096215f835b0f70c94d7b033da3cbf66181b619f25e54d65adaf825e62"
+dependencies = [
+ "memoffset",
+ "object",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,6 +954,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "metal"
@@ -1256,6 +1284,18 @@ dependencies = [
  "objc2",
  "objc2-core-location",
  "objc2-foundation",
+]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "crc32fast",
+ "hashbrown",
+ "indexmap",
+ "memchr",
 ]
 
 [[package]]
@@ -1609,6 +1649,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1806,21 +1855,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.8"
+name = "toml"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "900f6c86a685850b1bc9f6223b20125115ee3f31e01207d81655bbcc0aea9231"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "10558ed0bd2a1562e630926a2d1f0b98c827da99fabd3fe20920a59642504485"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28391a4201ba7eb1984cfeb6862c0b3ea2cfe23332298967c749dddc0d6cd976"
 
 [[package]]
 name = "tracing"
@@ -2585,9 +2658,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
 dependencies = [
  "memchr",
 ]
@@ -2692,8 +2765,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "implib",
  "serde",
- "serde_json",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "subrandr"
 version = "0.1.0"
 edition = "2021"
 
+[package.metadata.capi]
+# This is very crudely parsed by the build script, don't touch.
+abiver = "0"
+
 [lib]
 crate-type = ["rlib", "cdylib", "staticlib"]
 

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
-use std::process::Command;
+use std::{path::PathBuf, process::Command};
+
 fn main() {
     if let Ok(rev) = std::env::var("SUBRANDR_BUILD_REV") {
         println!("cargo:rustc-env=BUILD_REV={}", &rev[..7]);
@@ -23,5 +24,81 @@ fn main() {
             "cargo:rustc-env=BUILD_DIRTY={}",
             if is_dirty { " (dirty)" } else { "" }
         );
+    }
+
+    let abiver = {
+        let manifest_content =
+            std::fs::read_to_string(std::env::var_os("CARGO_MANIFEST_PATH").unwrap()).unwrap();
+
+        let mut result = None;
+        for line in manifest_content.lines() {
+            let Some((name, value)) = line.split_once('=') else {
+                continue;
+            };
+
+            if name.trim() == "abiver" {
+                if let Some(content) = value
+                    .trim()
+                    .strip_prefix('"')
+                    .and_then(|x| x.strip_suffix('"'))
+                {
+                    result = Some(content.to_owned());
+                    break;
+                }
+            }
+        }
+
+        result
+    }
+    .unwrap();
+
+    let os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap();
+    let major = std::env::var("CARGO_PKG_VERSION_MAJOR").unwrap();
+    let minor = std::env::var("CARGO_PKG_VERSION_MINOR").unwrap();
+    let patch = std::env::var("CARGO_PKG_VERSION_PATCH").unwrap();
+
+    let out_dir = PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
+    // cargo in its infinite wisdom refuses to provide you the target directory in build scripts
+    let target_dir = PathBuf::from_iter(
+        out_dir
+            .components()
+            .take_while(|x| x.as_os_str().to_str().is_none_or(|s| s != "build")),
+    );
+
+    macro_rules! cdylib_link_arg {
+        ($fmt: literal $($rest: tt)*) => {
+            println!(concat!("cargo:rustc-cdylib-link-arg=", $fmt) $($rest)*)
+        };
+    }
+
+    match (&*os, &*env) {
+        ("linux", _) => {
+            cdylib_link_arg!("-Wl,-soname,libsubrandr.so.{}", abiver);
+        }
+        ("macos", _) | ("ios", _) => {
+            // Searching "darwin linker man page" is the easiest way to find information about these.
+            cdylib_link_arg!("-Wl,-compatibility_version,{}", abiver);
+            cdylib_link_arg!("-Wl,-current_version,{}.{}.{}", major, minor, patch);
+        }
+        ("windows", "gnu") => {
+            // The Windows approach is, as usual, the most arcane.
+            // Apparently on Windows this is solved with stub "import libraries".
+            // BUT there is no way we can tell the linker at this point that
+            // "I want this import library to link to subrandr-1.dll instead of
+            // subrandr.dll", because why would -soname work? Then it would make sense,
+            // and we don't want that.
+            // So instead the approach is as follows:
+            // - Generate a .def file which contains all exported and imported
+            //   symbols in a format that can be processed by `dlltool` to create
+            //   an import library.
+            // - Generate an import library at install time, with the correct ABI
+            //   versioned dllname using the `implib` crate.
+            //   (finding a working `dlltool` for the target seems very fragile)
+            // Alternatively it would be nice if we could convince cargo to generate a
+            // "subrandr-1.dll" instead so that it could ""just"" work.
+            cdylib_link_arg!("-Wl,--output-def,{}/subrandr.def", target_dir.display());
+        }
+        _ => (),
     }
 }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0.98"
 clap = { version = "4.5.37", features = ["derive"] }
+implib = "0.3.5"
 serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.140"
+toml = "0.8.21"


### PR DESCRIPTION
Apparently versioning cdylibs is a problem that has not yet been solved by `cargo` (and there doesn't appear to be much work ongoing in that direction).

The Linux and friends way is naturally very simple and easy, set `SONAME` to a versioned filename and then symlink the non-versioned filename to the versioned filename, very clean.

The Windows way is maybe simple, what most packages appear to do is put the dll in the `bin` directory with its name suffixed by `-{abiversion}`. I have no idea whether it is truly this simple, it would be nice to check that this works before merging.

MacOS isn't even supported by the install xtask but to avoid having to find this information in the future I've also added its relevant linker flags for setting version information.