### PR TITLE
Use texture atlas and batch blits in wgpu rasterizer

### DIFF
--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -66,6 +66,13 @@ impl<N> Vec2<N> {
 }
 
 #[expect(dead_code)]
+impl<N: Number + Signed> Vec2<N> {
+    pub fn normal(self) -> Self {
+        Self::new(self.y, -self.x)
+    }
+}
+
+#[expect(dead_code)]
 impl<N: Number> Vec2<N> {
     pub fn length(self) -> N
     where
@@ -77,11 +84,6 @@ impl<N: Number> Vec2<N> {
     pub fn length_sq(self) -> N {
         self.x * self.x + self.y * self.y
     }
-
-    pub fn normal(self) -> Self {
-        Self::new(self.y, -self.x)
-    }
-
     /// Calculates the dot product of two vectors.
     ///
     /// The dot product of two (2d) vectors is defined for vector u and v as:
@@ -202,7 +204,7 @@ impl_binop!(
     Point2, -, _, Point2, Vec2
 );
 
-impl<N: Number> Neg for Vec2<N> {
+impl<N: Number + Signed> Neg for Vec2<N> {
     type Output = Self;
 
     fn neg(self) -> Self::Output {

--- a/src/math/num.rs
+++ b/src/math/num.rs
@@ -12,7 +12,6 @@ pub trait Number:
     + SubAssign<Self>
     + DivAssign<Self>
     + MulAssign<Self>
-    + Neg<Output = Self>
     + PartialOrd
     + Copy
 {
@@ -37,15 +36,27 @@ pub trait Number:
     const ZERO: Self;
 }
 
+pub trait Signed: Neg<Output = Self> {}
+
 impl Number for f32 {
     const MIN: Self = f32::MIN;
     const MAX: Self = f32::MAX;
     const ZERO: Self = 0.0;
 }
 
+impl Signed for f32 {}
+
 impl Number for i32 {
     const MIN: Self = i32::MIN;
     const MAX: Self = i32::MAX;
+    const ZERO: Self = 0;
+}
+
+impl Signed for i32 {}
+
+impl Number for u32 {
+    const MIN: Self = u32::MIN;
+    const MAX: Self = u32::MAX;
     const ZERO: Self = 0;
 }
 

--- a/src/rasterize.rs
+++ b/src/rasterize.rs
@@ -232,14 +232,12 @@ pub(crate) trait Rasterizer {
     /// Flush pending buffered draws.
     ///
     /// Some rasterizers, like the wgpu one, may batch some operations to reduce the amount of
-    /// binding and draw calls. These batched operations should eventually be flushed, and this
-    /// should be done soon enough to allow the GPU to get to work early but late enough that
-    /// the calls are batched enough to result in a performance increase.
+    /// binding and draw calls. These batched operations may be flushed to ensure they're executed
+    /// now rather than on the next batch-incompatible operation.
     ///
-    /// Note that this *should* be called at least somewhat frequently even if automatic flushing
-    /// would work correctly because the wgpu rasterizer also does defragmentation of texture atlases
-    /// here, without which it may use unbounded video memory.
-    fn flush(&mut self) {}
+    /// Note that currently this function will also defragment texture atlases although this may
+    /// be changed in the future to use a separate once per-frame housekeeping function.
+    fn flush(&mut self, _target: &mut RenderTarget) {}
 
     fn blur_prepare(&mut self, width: u32, height: u32, sigma: f32);
     fn blur_buffer_blit(&mut self, dx: i32, dy: i32, texture: &Texture);

--- a/src/rasterize/sw.rs
+++ b/src/rasterize/sw.rs
@@ -602,10 +602,6 @@ impl super::Rasterizer for Rasterizer {
         "software"
     }
 
-    fn adapter_info_string(&self) -> Option<String> {
-        None
-    }
-
     unsafe fn create_texture_mapped(
         &mut self,
         width: u32,

--- a/src/rasterize/wgpu/blit.wgsl
+++ b/src/rasterize/wgpu/blit.wgsl
@@ -7,21 +7,18 @@ struct VertexOutput {
     @interpolate(flat) @location(1) color: vec4<f32>
 }
 
-struct VertexInput {
-    @location(0) vertex: vec2<f32>,
-    @builtin(vertex_index) index: u32,
-}
-
 struct InstanceInput {
-    @location(1) pos: vec2<f32>,
-    @location(2) size: vec2<f32>,
-    @location(3) color: vec4<f32>
+    @location(0) src_pos: vec2<f32>,
+    @location(1) src_uv_size: vec2<f32>,
+    @location(2) dst_pos: vec2<f32>,
+    @location(3) size: vec2<f32>,
+    @location(4) color: vec4<f32>
 }
 
 @vertex
 fn vs_main(
-    vertex: VertexInput,
     instance: InstanceInput,
+    @builtin(vertex_index) index: u32,
 ) -> VertexOutput {
     let vertices = array<vec2<f32>, 4>(
         vec2<f32>(0.0, 1.0),
@@ -31,9 +28,11 @@ fn vs_main(
     );
 
     var out: VertexOutput;
-    out.src_coord = vertex.vertex;
+    out.src_coord = vec2<f32>(
+        instance.src_pos + (vertices[index] * instance.src_uv_size),
+    );
     out.position = vec4<f32>(
-        instance.pos + (vertices[vertex.index] * 2.0 - vec2f(1.0, 1.0)) * instance.size + instance.size,
+        instance.dst_pos + (vertices[index] * 2.0 - vec2f(1.0, 1.0)) * instance.size + instance.size,
         0.0, 1.0
     );
     out.color = instance.color;

--- a/src/rasterize/wgpu/blit.wgsl
+++ b/src/rasterize/wgpu/blit.wgsl
@@ -1,21 +1,27 @@
-struct BlitContext {
-    pos: vec2<f32>,
-    size: vec2<f32>,
-    color: vec4<f32>,
-}
-
 @group(0) @binding(0) var blit_sampler: sampler;
 @group(0) @binding(1) var blit_texture: texture_2d<f32>;
-@group(0) @binding(2) var<uniform> ctx: BlitContext;
 
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
-    @location(0) coord: vec2<f32>,
+    @location(0) src_coord: vec2<f32>,
+    @interpolate(flat) @location(1) color: vec4<f32>
+}
+
+struct VertexInput {
+    @location(0) vertex: vec2<f32>,
+    @builtin(vertex_index) index: u32,
+}
+
+struct InstanceInput {
+    @location(1) pos: vec2<f32>,
+    @location(2) size: vec2<f32>,
+    @location(3) color: vec4<f32>
 }
 
 @vertex
 fn vs_main(
-    @builtin(vertex_index) index: u32,
+    vertex: VertexInput,
+    instance: InstanceInput,
 ) -> VertexOutput {
     let vertices = array<vec2<f32>, 4>(
         vec2<f32>(0.0, 1.0),
@@ -25,11 +31,12 @@ fn vs_main(
     );
 
     var out: VertexOutput;
-    out.coord = vertices[index];
+    out.src_coord = vertex.vertex;
     out.position = vec4<f32>(
-        ctx.pos + (out.coord * 2.0 - vec2f(1.0, 1.0)) * ctx.size + ctx.size,
+        instance.pos + (vertices[vertex.index] * 2.0 - vec2f(1.0, 1.0)) * instance.size + instance.size,
         0.0, 1.0
     );
+    out.color = instance.color;
     return out;
 }
 
@@ -37,16 +44,16 @@ fn vs_main(
 fn fs_main_mono_to_bgra(
     in: VertexOutput
 ) -> @location(0) vec4<f32> {
-    let sample = textureSample(blit_texture, blit_sampler, in.coord).x;
-    return ctx.color * sample;
+    let sample = textureSample(blit_texture, blit_sampler, in.src_coord).x;
+    return in.color * sample;
 }
 
 @fragment
 fn fs_main_bgra_to_bgra(
     in: VertexOutput
 ) -> @location(0) vec4<f32> {
-    var sample = textureSample(blit_texture, blit_sampler, in.coord);
-    sample.w *= ctx.color.w;
+    var sample = textureSample(blit_texture, blit_sampler, in.src_coord);
+    sample.w *= in.color.w;
     return sample;
 }
 
@@ -54,7 +61,7 @@ fn fs_main_bgra_to_bgra(
 fn fs_main_mono_to_mono(
     in: VertexOutput
 ) -> @location(0) vec4<f32> {
-    return textureSample(blit_texture, blit_sampler, in.coord);
+    return textureSample(blit_texture, blit_sampler, in.src_coord);
 }
 
 @fragment
@@ -62,7 +69,7 @@ fn fs_main_xxxa_to_mono(
     in: VertexOutput
 ) -> @location(0) vec4<f32> {
     return vec4f(
-        textureSample(blit_texture, blit_sampler, in.coord).a,
+        textureSample(blit_texture, blit_sampler, in.src_coord).a,
         0.0,
         0.0,
         1.0

--- a/src/rasterize/wgpu/packer.rs
+++ b/src/rasterize/wgpu/packer.rs
@@ -1,0 +1,371 @@
+use std::{
+    cell::Cell,
+    collections::HashMap,
+    fmt::Write,
+    rc::{Rc, Weak},
+};
+
+use wgpu::TextureFormat;
+
+use crate::math::{Point2, Vec2};
+
+/// A texture packer that packs stuff into (potentially multiple) atlas textures.
+///
+/// Freeing a texture is implemented by tracking the amount of freed space,
+/// which is intially wasted, and recreating the whole atlas once too much space is wasted.
+/// Note that freed space is *not* added to the free block pool, this could be changed but
+/// will still result in fragmentation so a mechanism to occasionally defragment the atlas is
+/// necessary anyway.
+pub struct TexturePacker {
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    format: TextureFormat,
+    textures: HashMap<u32, AtlasTexture>,
+    next_texture_id: u32,
+    free: Vec<FreeBlock>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FreeBlock {
+    texture: u32,
+    size: Vec2<u32>,
+    position: Point2<u32>,
+}
+
+impl FreeBlock {
+    fn fits(&self, request: Vec2<u32>) -> bool {
+        self.size.x >= request.x && self.size.y >= request.y
+    }
+}
+
+#[derive(Debug)]
+struct AtlasTexture {
+    texture: wgpu::Texture,
+    allocated: Vec<Weak<AllocatedBlock>>,
+    wasted_space: Rc<Cell<u32>>,
+}
+
+#[derive(Debug, Clone)]
+struct AllocatedBlock {
+    texture: Cell<u32>,
+    position: Cell<Point2<u32>>,
+    size: Vec2<u32>,
+    wasted_space: Rc<Cell<u32>>,
+}
+
+impl Drop for AllocatedBlock {
+    fn drop(&mut self) {
+        let size = self.size;
+        self.wasted_space
+            .set(self.wasted_space.get() + size.x * size.y);
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PackedTexture {
+    block: Rc<AllocatedBlock>,
+}
+
+impl PackedTexture {
+    pub fn size(&self) -> Vec2<u32> {
+        self.block.size
+    }
+
+    pub fn get_texture_region<'a>(
+        &self,
+        packer: &'a TexturePacker,
+    ) -> (&'a wgpu::Texture, Point2<u32>, Vec2<u32>) {
+        (
+            &packer.textures[&self.block.texture.get()].texture,
+            self.block.position.get(),
+            self.block.size,
+        )
+    }
+}
+
+impl TexturePacker {
+    pub fn new(device: wgpu::Device, queue: wgpu::Queue, format: TextureFormat) -> Self {
+        Self {
+            device,
+            queue,
+            format,
+            textures: HashMap::new(),
+            next_texture_id: 0,
+            free: Vec::new(),
+        }
+    }
+
+    fn desired_atlas_texture_size(&self, min: u32) -> u32 {
+        let desired = 2 << (self.textures.len() + 9).min(12);
+        let limit = self.device.limits().max_texture_dimension_2d;
+        desired.min(limit).max(min)
+    }
+
+    fn split_free(&mut self, free: &FreeBlock, size: Vec2<u32>) {
+        let lower_size = Vec2::new(free.size.x, free.size.y - size.y);
+        if lower_size.x != 0 && lower_size.y != 0 {
+            self.free.push(FreeBlock {
+                texture: free.texture,
+                size: lower_size,
+                position: free.position + Vec2::new(0, size.y),
+            });
+        }
+
+        let right_size = Vec2::new(free.size.x - size.x, size.y);
+        if right_size.x != 0 && right_size.y != 0 {
+            self.free.push(FreeBlock {
+                texture: free.texture,
+                size: right_size,
+                position: free.position + Vec2::new(size.x, 0),
+            });
+        }
+    }
+
+    fn allocate_block(&mut self, size: Vec2<u32>) -> FreeBlock {
+        if let Some(idx) = self.free.iter().rposition(|free| free.fits(size)) {
+            let block = self.free.swap_remove(idx);
+
+            self.split_free(&block, size);
+            self.free
+                .sort_by_key(|free| std::cmp::Reverse(free.size.x * free.size.y));
+
+            block
+        } else {
+            let new_atlas_size = self.desired_atlas_texture_size(size.x.max(size.y));
+            let texture = self.device.create_texture(&wgpu::wgt::TextureDescriptor {
+                label: Some(&format!(
+                    "{:?} atlas {1}x{1} texture",
+                    self.format, new_atlas_size
+                )),
+                size: wgpu::Extent3d {
+                    width: new_atlas_size,
+                    height: new_atlas_size,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: self.format,
+                usage: wgpu::TextureUsages::COPY_SRC
+                    | wgpu::TextureUsages::COPY_DST
+                    | wgpu::TextureUsages::TEXTURE_BINDING,
+                view_formats: &[self.format],
+            });
+
+            let texture_id = self.next_texture_id;
+            self.next_texture_id += 1;
+
+            let full_block = FreeBlock {
+                texture: texture_id,
+                size: Vec2::new(new_atlas_size, new_atlas_size),
+                position: Point2::ZERO,
+            };
+
+            self.split_free(&full_block, size);
+
+            self.textures.insert(
+                texture_id,
+                AtlasTexture {
+                    texture,
+                    allocated: Vec::new(),
+                    wasted_space: Rc::new(Cell::new(0)),
+                },
+            );
+
+            full_block
+        }
+    }
+
+    /// Defragments texture atlases belonging to this packer.
+    ///
+    /// Note that this may change what textures existing `PackedTexture`s derived from this
+    /// packer point to, thus it shall not be called if those are expected not to change, like
+    /// when a draw is being actively batched.
+    pub fn defragment(&mut self) {
+        // TODO: hash_extract_if will be stabilised in 1.88.0
+        //       they delayed it from 1.87 :(
+        // let fragmented = self
+        //     .textures
+        //     .extract_if(|_, atlas| {
+        //         let total_space = atlas.texture.width() * atlas.texture.height();
+        //         // This texture has 1/3 of its space unused, take it out and
+        //         // we'll reinsert its components into a new texture.
+        //         atlas.wasted_space.get() * 3 >= total_space
+        //     })
+        //     .map(|(_, atlas)| atlas)
+        //     .collect::<Vec<_>>();
+
+        // Written this way to allow replacing with above code immediately after hash_extract_if is
+        // stabilised.
+        let fragmented = {
+            self.textures
+                .iter()
+                .filter_map(|(&key, atlas)| {
+                    let total_space = atlas.texture.width() * atlas.texture.height();
+                    // This texture has 1/3 of its space unused, take it out and
+                    // we'll reinsert its components into a new texture.
+                    if atlas.wasted_space.get() * 3 >= total_space {
+                        Some(key)
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>()
+                .into_iter()
+                .map(|id| self.textures.remove(&id).unwrap())
+                .collect::<Vec<_>>()
+        };
+
+        self.free
+            .retain(|free| self.textures.contains_key(&free.texture));
+
+        for atlas in fragmented {
+            for weak_block in atlas.allocated {
+                if let Some(block) = weak_block.upgrade() {
+                    self.relocate_block(&atlas.texture, block, weak_block);
+                }
+            }
+        }
+    }
+
+    fn relocate_block(
+        &mut self,
+        texture: &wgpu::Texture,
+        allocated_block: Rc<AllocatedBlock>,
+        weak_allocated_block: Weak<AllocatedBlock>,
+    ) {
+        let size = allocated_block.size;
+        let block = self.allocate_block(size);
+        let atlas = self.textures.get_mut(&block.texture).unwrap();
+
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("texture texture atlas move encoder"),
+            });
+        encoder.copy_texture_to_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d {
+                    x: allocated_block.position.get().x,
+                    y: allocated_block.position.get().y,
+                    z: 0,
+                },
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyTextureInfo {
+                texture: &atlas.texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d {
+                    x: block.position.x,
+                    y: block.position.y,
+                    z: 0,
+                },
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::Extent3d {
+                width: size.x,
+                height: size.y,
+                depth_or_array_layers: 1,
+            },
+        );
+        self.queue.submit([encoder.finish()]);
+
+        allocated_block.texture.set(block.texture);
+        allocated_block.position.set(block.position);
+        atlas.allocated.push(weak_allocated_block);
+    }
+
+    pub fn add_from_buffer(
+        &mut self,
+        buffer: &wgpu::Buffer,
+        stride: u32,
+        width: u32,
+        height: u32,
+    ) -> PackedTexture {
+        let size = Vec2::new(width, height);
+        let block = self.allocate_block(size);
+        let atlas = self.textures.get_mut(&block.texture).unwrap();
+
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("buffer -> texture atlas move encoder"),
+            });
+        encoder.copy_buffer_to_texture(
+            wgpu::TexelCopyBufferInfo {
+                buffer,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(stride),
+                    rows_per_image: None,
+                },
+            },
+            wgpu::TexelCopyTextureInfo {
+                texture: &atlas.texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d {
+                    x: block.position.x,
+                    y: block.position.y,
+                    z: 0,
+                },
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+        );
+        self.queue.submit([encoder.finish()]);
+
+        let allocated = Rc::new(AllocatedBlock {
+            position: Cell::new(block.position),
+            size,
+            texture: Cell::new(block.texture),
+            wasted_space: atlas.wasted_space.clone(),
+        });
+
+        atlas.allocated.push(Rc::downgrade(&allocated));
+
+        PackedTexture { block: allocated }
+    }
+
+    pub(crate) fn write_atlas_stats(&self, writer: &mut dyn Write) -> std::fmt::Result {
+        writeln!(writer, "{} atlas textures", self.textures.len())?;
+
+        let bytes_per_pixel = self.format.target_pixel_byte_cost().unwrap();
+        writeln!(
+            writer,
+            "{} total bytes {} wasted bytes {} free bytes",
+            self.textures
+                .values()
+                .map(|atlas| atlas.texture.width() * atlas.texture.height())
+                .sum::<u32>()
+                * bytes_per_pixel,
+            self.textures
+                .values()
+                .map(|atlas| atlas.wasted_space.get())
+                .sum::<u32>()
+                * bytes_per_pixel,
+            self.free
+                .iter()
+                .map(|free| free.size.x * free.size.y)
+                .sum::<u32>()
+                * bytes_per_pixel,
+        )?;
+
+        writeln!(
+            writer,
+            "{} allocated blocks {} free blocks",
+            self.textures
+                .values()
+                .map(|atlas| atlas.allocated.len())
+                .sum::<usize>(),
+            self.free.len()
+        )?;
+
+        Ok(())
+    }
+}

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -646,16 +646,21 @@ impl Renderer<'_> {
                 )?;
                 y += debug_line_height;
 
-                if let Some(adapter_line) = pass.rasterizer.adapter_info_string() {
-                    pass.debug_text(
-                        target,
-                        Point2L::new(FixedL::ZERO, y),
-                        &adapter_line,
-                        Alignment(HorizontalAlignment::Left, VerticalAlignment::Top),
-                        debug_font_size,
-                        BGRA8::WHITE,
-                    )?;
-                    y += debug_line_height;
+                {
+                    let mut rasterizer_debug_info = String::new();
+                    _ = pass.rasterizer.write_debug_info(&mut rasterizer_debug_info);
+
+                    for line in rasterizer_debug_info.lines() {
+                        pass.debug_text(
+                            target,
+                            Point2L::new(FixedL::ZERO, y),
+                            line,
+                            Alignment(HorizontalAlignment::Left, VerticalAlignment::Top),
+                            debug_font_size,
+                            BGRA8::WHITE,
+                        )?;
+                        y += debug_line_height;
+                    }
                 }
             }
 
@@ -919,6 +924,8 @@ impl Renderer<'_> {
                     }
                 }
             }
+
+            pass.rasterizer.flush();
         }
 
         let time = self.perf.end_frame();

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -765,6 +765,8 @@ impl Renderer<'_> {
                     draw_polyline(&self.perf.raster, BGRA8::ORANGERED);
                     y += graph_height;
                 }
+
+                pass.rasterizer.flush(target);
             }
             self.perf.end_debug_raster();
 
@@ -925,7 +927,9 @@ impl Renderer<'_> {
                 }
             }
 
-            pass.rasterizer.flush();
+            // Make sure all batched draws are flushed, although currently this is not
+            // necessary because the wgpu rasterizer flushes automatically on `submit_render`.
+            pass.rasterizer.flush(target);
         }
 
         let time = self.perf.end_frame();

--- a/src/text/face.rs
+++ b/src/text/face.rs
@@ -682,7 +682,7 @@ impl Drop for Font {
     }
 }
 
-#[derive(PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 struct SizeInfo {
     coords: MmCoords,
     point_size: I26Dot6,
@@ -1032,7 +1032,7 @@ impl Font {
                 _ => return Err(GlyphRenderError::UnsupportedBitmapFormat(bitmap.pixel_mode)),
             };
 
-            let texture = rasterizer.create_texture_mapped(
+            let texture = rasterizer.create_packed_texture_mapped(
                 scaled_width,
                 scaled_height,
                 if matches!(pixel_mode, CopyPixelMode::Bgra32) {


### PR DESCRIPTION
This significantly improves performance due to the dramatically reduced amount of draw calls.

TODO:
- [ ] Attempt to make batching callback based instead of `flush()` based to reduce the likelihood of draw order issues caused by batching and simplify rasterizer state.