### PR TITLE
More closely match CSS line-height calculation

### DIFF
--- a/src/layout.rs
+++ b/src/layout.rs
@@ -172,6 +172,7 @@ fn layout_inline(
                 .get_copy_or::<style::WordBreak, _>(LineBreakWordOption::Normal),
         },
         constraints.size.x,
+        text::layout::LineHeight::Normal,
         unsafe { std::mem::transmute::<&FontArena, &'static FontArena>(&font_arena) },
         context.fonts,
     )?;

--- a/src/text/face.rs
+++ b/src/text/face.rs
@@ -122,6 +122,12 @@ pub struct FontMetrics {
     pub strikeout_thickness: I26Dot6,
 }
 
+impl FontMetrics {
+    pub fn line_gap(&self) -> I26Dot6 {
+        self.height - self.ascender + self.descender
+    }
+}
+
 trait FaceImpl: Sized {
     type Font: FontImpl<Face = Self>;
 


### PR DESCRIPTION
Fixes #13 

This makes subrandr's incorrect background box handling more apparent so proper layered rendering should be implemented first.