### PR TITLE
Add mechanism for manually adding fonts

### DIFF
--- a/include/font_provider.h
+++ b/include/font_provider.h
@@ -1,0 +1,48 @@
+#ifndef SBR_FONT_PROVIDER_H
+#define SBR_FONT_PROVIDER_H
+
+#include "subrandr.h"
+
+#ifdef __cplusplus
+#include <cstddef>
+
+extern "C" {
+#else
+#include <stddef.h>
+#endif
+
+typedef struct sbr_custom_font_provider sbr_custom_font_provider;
+
+// Returns a new empty custom font provider.
+sbr_custom_font_provider *sbr_custom_font_provider_create(void);
+
+// Adds a single in-memory font to this font provider.
+//
+// Note that the font is immediately copied into a new buffer, parsed and the
+// information within used to add to the internal index built by this font
+// provider.
+int sbr_custom_font_provider_add_from_memory(
+    sbr_custom_font_provider *provider, const char *data, size_t data_len
+);
+
+// Adds all fonts found directly inside the specified directory.
+//
+// Note that the passed directory will be immediately scanned for fonts and all
+// contained fonts opened and added to the internal index.
+//
+// Additionally, currently all fonts found within this directory will be kept
+// open for the entire lifetime of this font provider. Clients passing untrusted
+// paths to this function must consider the potential for Denial-of-Service
+// caused by memory exhaustion if the directory contains very large fonts.
+//
+// The precise behavior of this function as described above is subject to
+// change.
+int sbr_custom_font_provider_add_all_from_dir(
+    sbr_custom_font_provider *provider, const char *path
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SBR_FONT_PROVIDER_H

--- a/include/subrandr.h
+++ b/include/subrandr.h
@@ -25,6 +25,7 @@ extern "C" {
 
 typedef struct sbr_library sbr_library;
 typedef struct sbr_subtitles sbr_subtitles;
+typedef struct sbr_custom_font_provider sbr_custom_font_provider;
 typedef struct sbr_renderer sbr_renderer;
 typedef int32_t sbr_26dot6;
 typedef struct sbr_subtitle_context {
@@ -43,13 +44,13 @@ typedef int16_t sbr_subtitle_format;
 #define SBR_SUBTITLE_FORMAT_SRV3 (sbr_subtitle_format)1
 #define SBR_SUBTITLE_FORMAT_WEBVTT (sbr_subtitle_format)2
 
-// Probe subtitle text for a matching format magic.
+// Probes subtitle text for a matching format magic.
 //
 // This function tries to determine the subtitle format of `content`
 // on a best-effort basis.
 sbr_subtitle_format sbr_probe_text(char const *content, size_t content_len);
 
-// Load subtitles from text data.
+// Loads subtitles from text data.
 //
 // If `format` is not SBR_SUBTITLE_FORMAT_UNKNOWN then subrandr will assume
 // subtitles are in the given subtitle format and parse them accordingly.
@@ -71,10 +72,21 @@ SBR_UNSTABLE sbr_subtitles *sbr_load_file(sbr_library *, char const *path);
 void sbr_subtitles_destroy(sbr_subtitles *);
 
 sbr_renderer *sbr_renderer_create(sbr_library *);
+
 void sbr_renderer_set_subtitles(sbr_renderer *, sbr_subtitles *);
+
+// Sets a custom font provider for use by this renderer.
+//
+// All font lookups done by this renderer will first go through the provided
+// custom font provider before they reach system font fallback.
+void sbr_renderer_set_custom_font_provider(
+    sbr_renderer *, sbr_custom_font_provider *
+);
+
 bool sbr_renderer_did_change(
     sbr_renderer *, sbr_subtitle_context const *, uint32_t t
 );
+
 int sbr_renderer_render(
     sbr_renderer *, sbr_subtitle_context const *,
     // current time value in milliseconds
@@ -82,6 +94,7 @@ int sbr_renderer_render(
     // BGRA8 pixel buffer
     uint32_t *buffer, uint32_t width, uint32_t height, uint32_t stride
 );
+
 void sbr_renderer_destroy(sbr_renderer *);
 
 typedef uint32_t SBR_UNSTABLE sbr_error_code;

--- a/src/text/face.rs
+++ b/src/text/face.rs
@@ -16,6 +16,7 @@ use util::math::{I16Dot16, I26Dot6, Vec2};
 use super::FreeTypeError;
 
 pub mod freetype;
+pub mod panose;
 pub use freetype::GlyphRenderError;
 mod tofu;
 

--- a/src/text/face.rs
+++ b/src/text/face.rs
@@ -14,6 +14,7 @@ use text_sys::hb_font_t;
 use util::math::{I16Dot16, I26Dot6, Vec2};
 
 use super::FreeTypeError;
+use crate::text::FontAxisValues;
 
 pub mod freetype;
 pub mod panose;
@@ -139,7 +140,11 @@ trait FaceImpl: Sized {
     fn set_axis(&mut self, index: usize, value: I16Dot16);
 
     fn weight(&self) -> I16Dot16;
+    fn weight_range(&self) -> FontAxisValues;
     fn italic(&self) -> bool;
+    fn italic_range(&self) -> FontAxisValues;
+
+    fn contains_codepoint(&self, codepoint: u32) -> bool;
 
     type Error;
     fn with_size(&self, point_size: I26Dot6, dpi: u32) -> Result<Self::Font, Self::Error>;
@@ -319,7 +324,11 @@ impl Face {
         pub fn set_axis[&mut](index: usize, value: I16Dot16) -> ();
 
         pub fn weight[&]() -> I16Dot16;
+        pub fn weight_range[&]() -> FontAxisValues;
         pub fn italic[&]() -> bool;
+        pub fn italic_range[&]() -> FontAxisValues;
+
+        pub fn contains_codepoint[&mut](value: u32) -> bool;
     );
 
     pub fn with_size(&self, point_size: I26Dot6, dpi: u32) -> Result<Font, FreeTypeError> {

--- a/src/text/face/freetype.rs
+++ b/src/text/face/freetype.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 use util::math::{I16Dot16, I26Dot6, Vec2};
 
 use super::{
-    Axis, FaceImpl, FontImpl, FontMetrics, GlyphCache, GlyphMetrics, OpenTypeTag,
+    panose, Axis, FaceImpl, FontImpl, FontMetrics, GlyphCache, GlyphMetrics, OpenTypeTag,
     SingleGlyphBitmap, ITALIC_AXIS, WEIGHT_AXIS,
 };
 use crate::{outline::Outline, text::ft_utils::*};
@@ -178,6 +178,13 @@ impl Face {
             let table = FT_Get_Sfnt_Table(self.face, FT_SFNT_OS2) as *const TT_OS2;
             table.as_ref().map(|os2| os2.usWeightClass)
         }
+    }
+}
+
+impl Face {
+    pub fn panose(&self) -> Option<panose::Classification> {
+        unsafe { (FT_Get_Sfnt_Table(self.face, FT_SFNT_OS2) as *const TT_OS2).as_ref() }
+            .and_then(|os2| panose::Classification::parse(os2.panose))
     }
 }
 

--- a/src/text/face/freetype.rs
+++ b/src/text/face/freetype.rs
@@ -88,7 +88,7 @@ impl SharedFaceData {
 
 #[repr(C)]
 #[derive(PartialEq, Eq, Hash)]
-pub(super) struct Face {
+pub struct Face {
     face: FT_Face,
     coords: MmCoords,
 }
@@ -417,7 +417,7 @@ unsafe fn build_font_metrics(
 }
 
 #[repr(C)]
-pub(super) struct Font {
+pub struct Font {
     // owned by hb_font
     ft_face: FT_Face,
     coords: MmCoords,

--- a/src/text/face/panose.rs
+++ b/src/text/face/panose.rs
@@ -1,0 +1,134 @@
+//! Some basic [PANOSE font classification system](https://monotype.github.io/panose/pan1.htm) types
+//! that are useful for extracting style information from fonts that have it.
+//!
+//! Only the values that are actually useful for us are defined here.
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum Classification {
+    Any,
+    NoFit,
+    LatinText(LatinText),
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub struct LatinText {
+    pub serif_style: SerifStyle,
+    pub weight: Weight,
+    pub proportion: Proportion,
+}
+
+impl LatinText {
+    fn parse(number: [u8; 10]) -> Option<LatinText> {
+        Some(LatinText {
+            serif_style: SerifStyle::from_value(number[1])?,
+            weight: Weight::from_value(number[2])?,
+            proportion: Proportion::from_value(number[3])?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[expect(dead_code)] // transmute means these are "never constructed"
+pub enum SerifStyle {
+    Any = 0,
+    NoFit,
+    Cove,
+    ObtuseCove,
+    SquareCove,
+    ObtuseSquareCove,
+    Square,
+    Thin,
+    Oval,
+    Exaggerated,
+    Triangle,
+    NormalSans,
+    ObtuseSans,
+    PerpendicularSans,
+    Flared,
+    Rounded,
+}
+
+impl SerifStyle {
+    fn from_value(value: u8) -> Option<SerifStyle> {
+        if value > Self::Rounded as u8 {
+            return None;
+        }
+
+        unsafe { std::mem::transmute(value) }
+    }
+
+    pub fn is_sans_serif(self) -> bool {
+        matches!(
+            self,
+            Self::Any
+                | Self::Flared
+                | Self::Rounded
+                | Self::PerpendicularSans
+                | Self::ObtuseSans
+                | Self::NormalSans
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[expect(dead_code)] // transmute means these are "never constructed"
+pub enum Weight {
+    Any = 0,
+    NoFit,
+    VeryLight,
+    Light,
+    Thin,
+    Book,
+    Medium,
+    Demi,
+    Bold,
+    Heavy,
+    Black,
+    ExtraBlack,
+}
+
+impl Weight {
+    fn from_value(value: u8) -> Option<Weight> {
+        if value > Self::ExtraBlack as u8 {
+            return None;
+        }
+
+        unsafe { std::mem::transmute(value) }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[expect(dead_code)] // transmute means these are "never constructed"
+pub enum Proportion {
+    Any = 0,
+    NoFit,
+    OldStyle,
+    Modern,
+    EvenWidth,
+    Extended,
+    Condensed,
+    VeryExtended,
+    VeryCondensed,
+    Monospaced,
+}
+
+impl Proportion {
+    fn from_value(value: u8) -> Option<Proportion> {
+        if value > Self::Monospaced as u8 {
+            return None;
+        }
+
+        unsafe { std::mem::transmute(value) }
+    }
+}
+
+impl Classification {
+    pub fn parse(number: [u8; 10]) -> Option<Classification> {
+        match number[0] {
+            0 => Some(Classification::Any),
+            1 => Some(Classification::NoFit),
+            2 => LatinText::parse(number).map(Classification::LatinText),
+            _ => None,
+        }
+    }
+}

--- a/src/text/face/tofu.rs
+++ b/src/text/face/tofu.rs
@@ -40,8 +40,21 @@ impl FaceImpl for Face {
         I16Dot16::new(400)
     }
 
+    fn weight_range(&self) -> crate::text::FontAxisValues {
+        crate::text::FontAxisValues::Fixed(self.weight())
+    }
+
     fn italic(&self) -> bool {
         false
+    }
+
+    fn italic_range(&self) -> crate::text::FontAxisValues {
+        crate::text::FontAxisValues::Fixed(I16Dot16::ZERO)
+    }
+
+    fn contains_codepoint(&self, codepoint: u32) -> bool {
+        _ = codepoint;
+        true
     }
 
     type Error = Infallible;


### PR DESCRIPTION
This adds a custom font provider mechanism through which a client can manually add fonts to be used by subrandr.

This provider basically implements a "small internal fontconfig" that retrieves information from fonts and tries to pick a font based on the information contained within.

Very WIP and unfinished, am working on other stuff concurrently and want to try doing some other things quickly before this is finished.