### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,7 +34,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: rustup component add rustfmt
+        with:
+          components: rustfmt
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt update && sudo apt install -y build-essential libfontconfig-dev libfreetype-dev libharfbuzz-dev
 
@@ -48,7 +49,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: rustup target add wasm32-wasip1
+        with:
+          targets: wasm32-wasip1
       - uses: Swatinem/rust-cache@v2
       - run: sudo apt update && sudo apt install -y build-essential
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,7 +41,7 @@ jobs:
 
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --exclude sbr-overlay --all-features -- -D warnings
-      - run: cargo xtask install --prefix prefix
+      - run: ./ci/c_sanity_check.sh
 
   check-wasi:
     name: Check wasm32-wasip1
@@ -89,4 +89,4 @@ jobs:
       - shell: msys2 {0}
         run: cargo clippy --workspace --exclude sbr-overlay --all-features -- -D warnings
       - shell: msys2 {0}
-        run: cargo xtask install --prefix prefix
+        run: ./ci/c_sanity_check.sh

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,8 +29,16 @@ jobs:
       - run: nix build --print-build-logs .
 
   check-linux:
-    name: Check
-    runs-on: ubuntu-latest
+    name: Check ${{ matrix.name }}
+    runs-on: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: x86_64 Linux
+            image: ubuntu-latest
+          - name: aarch64 Linux
+            image: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -69,21 +77,31 @@ jobs:
       - run: cargo build --target wasm32-wasip1 -p subrandr --all-features
 
   check-windows:
-    name: Check Windows
-    runs-on: windows-latest
+    name: Check ${{ matrix.name }}
+    runs-on: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: x86_64 Windows
+            image: windows-latest
+            msystem: MINGW64
+          # FIXME: aarch64 is broken because implib produces garbage implibs for it
+          # - name: aarch64 Windows
+          #   image: windows-11-arm
+          #   msystem: CLANGARM64
     steps:
       - uses: actions/checkout@v4
       - uses: msys2/setup-msys2@v2
         with:
-          msystem: MINGW64
+          msystem: ${{ matrix.msystem }}
           update: true
-          install: >-
-            git
-            mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-freetype
-            mingw-w64-x86_64-harfbuzz
-            mingw-w64-x86_64-freetype
-            mingw-w64-x86_64-rust
+          install: git
+          pacboy: >-
+            gcc:p
+            freetype:p
+            harfbuzz:p
+            rust:p
 
       - uses: Swatinem/rust-cache@v2
       - shell: msys2 {0}

--- a/ci/c_sanity_check.c
+++ b/ci/c_sanity_check.c
@@ -1,0 +1,16 @@
+#include <stdint.h>
+#include <stdio.h>
+
+#include "subrandr/subrandr.h"
+
+int main() {
+  uint32_t a, b, c;
+  sbr_library_version(&a, &b, &c);
+  printf("subrandr v%u.%u.%u\n", a, b, c);
+
+  sbr_library *lib = sbr_library_init();
+  sbr_renderer *r = sbr_renderer_create(lib);
+  printf("renderer %p created\n", r);
+  sbr_renderer_destroy(r);
+  sbr_library_fini(lib);
+}

--- a/ci/c_sanity_check.sh
+++ b/ci/c_sanity_check.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd ci
+cargo xtask install --prefix pfx
+mkdir -p pfx/bin
+"${CC:-cc}" -I pfx/include ./c_sanity_check.c -L pfx/lib -lsubrandr -o pfx/bin/sanity_check.exe
+
+export LD_LIBRARY_PATH=$PWD/pfx/lib
+cd pfx/bin
+
+./sanity_check.exe

--- a/src/text/font_provider/fontconfig.rs
+++ b/src/text/font_provider/fontconfig.rs
@@ -357,7 +357,7 @@ impl FontProvider for FontconfigFontProvider {
                 FcPatternAddString,
                 PatternAddString,
                 FC_FAMILY,
-                cname.as_ptr() as *const u8,
+                cname.as_ptr().cast(),
                 family.to_string()
             );
         }


### PR DESCRIPTION
Adds testing for aarch64 Linux on CI, fixes a warning that occurs in that case, and adds a test that actually checks whether the C library works by compiling a tiny test program.

I found out that aarch64 Windows is utterly broken because the implib crate generates completely bogus ARM64 assembly (it uses regular ARM assembly, ARM64 is not backwards compatible like that...), I'll disable building for aarch64 Windows in the xtask in another PR.