### PR TITLE
Use light hinting and round text y position

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -908,7 +908,7 @@ impl Renderer<'_> {
                             pass.draw_text_full(
                                 target,
                                 current.x + text.baseline_offset.x,
-                                current.y + text.baseline_offset.y,
+                                (current.y + text.baseline_offset.y).round(),
                                 text.glyphs(),
                                 text.style.color(),
                                 &text.style.text_decoration(),


### PR DESCRIPTION
See comment:
https://github.com/afishhh/subrandr/blob/212d0cf7ea0076792a5943eccb42ea25c64b81d1/src/text/face/freetype.rs#L21-L35

TLDR: Horizontal hinting is functionally incompatible with subpixel positioning when using HarfBuzz

Text y-coordinates are now rounded to integers to make sure the hinting actually works too.

TODO:
- [x] The description of `FT_LOAD_TARGET_LIGHT` contains the following ominous passage "Advance widths are rounded to integer values". Check if this also applies to `metrics.horiAdvance` and use the suggested `lsb_delta` and `rsb_delta` fields to unround them. (these metrics aren't actually used anywhere though so it doesn't *really* matter)

Additional notes: Text rendering truly is an arcane art that you must acquire by scouring the internet for hours. I feel like leaving the above comment is setting a bad precedent that information should be readily accessible, maybe I should remove it.