### PR TITLE
Use pointer transmute for glyph cache accesses

### DIFF
--- a/src/text/glyph_cache.rs
+++ b/src/text/glyph_cache.rs
@@ -162,15 +162,11 @@ impl GlyphCache {
         let slot = occupied.get();
         slot.generation.set(self.generation.get());
         // SAFETY: This reference is behind a Box and won't be removed from the map
-        //         without a &mut reference to the glyph cache.
-        //         The entry is only ever accessed immutably.
-        Ok(unsafe {
-            std::mem::transmute::<&V, &'static V>(
-                (&slot.value as &dyn Any)
-                    .downcast_ref::<V>()
-                    .unwrap_unchecked(),
-            )
-        })
+        //         without a &mut reference to the glyph cache and the entry is only
+        //         ever accessed immutably.
+        //         The type of the value must match because the `TypeId` is part of the
+        //         cache key.
+        Ok(unsafe { &*(&raw const slot.value as *const () as *const V) })
     }
 }
 


### PR DESCRIPTION
This removes the need for a trait upcast which is only stable in Rust >=1.86.0 and is probably slower than just doing a raw pointer cast.

Makes the crate compile with `1.85.0` which is what dinosaur distro Debian just updated to. Officially I'm still not committing to a strict MSRV and it is not checked in CI, but this is a small and generally beneficial change anyway so why not.