### PR TITLE
Fix incorrect post-shaping advance for scaled bitmap fonts

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -111,13 +111,16 @@ impl<'f> Glyph<'f> {
         original_cluster: usize,
         font: &'f Font,
     ) -> Self {
+        // Fix up incorrect metrics for scaled bitmap glyphs which HarfBuzz sees as unscaled.
+        let scale = font.harfbuzz_scale_factor_for(info.codepoint);
+
         Self {
             index: info.codepoint,
             cluster: original_cluster,
-            x_advance: I26Dot6::from_raw(position.x_advance),
-            y_advance: I26Dot6::from_raw(position.y_advance),
-            x_offset: I26Dot6::from_raw(position.x_offset),
-            y_offset: I26Dot6::from_raw(position.y_offset),
+            x_advance: I26Dot6::from_raw(position.x_advance) * scale,
+            y_advance: I26Dot6::from_raw(position.y_advance) * scale,
+            x_offset: I26Dot6::from_raw(position.x_offset) * scale,
+            y_offset: I26Dot6::from_raw(position.y_offset) * scale,
             font,
             flags: unsafe { hb_glyph_info_get_glyph_flags(info) },
         }

--- a/src/text/face.rs
+++ b/src/text/face.rs
@@ -160,6 +160,10 @@ trait FontImpl: Sized {
 
     fn metrics(&self) -> &FontMetrics;
     fn point_size(&self) -> I26Dot6;
+    // Used to fix HarfBuzz metrics for scaled bitmap fonts which HarfBuzz sees in
+    // their unscaled form. It would be ideal to instead handle this in
+    // the font funcs but that's non-trivial so this works.
+    fn harfbuzz_scale_factor_for(&self, glyph: u32) -> I26Dot6;
 
     fn size_cache_key(&self) -> FontSizeCacheKey;
 
@@ -267,6 +271,7 @@ impl Font {
         fn size_cache_key[&]() -> FontSizeCacheKey;
         pub fn metrics[&]() -> &FontMetrics;
         pub fn point_size[&]() -> I26Dot6;
+        pub fn harfbuzz_scale_factor_for[&](glyph: u32) -> I26Dot6;
     );
 
     fn face(&self) -> Face {

--- a/src/text/face/freetype.rs
+++ b/src/text/face/freetype.rs
@@ -666,6 +666,19 @@ impl FontImpl for Font {
         self.size.point_size
     }
 
+    // FIXME: This is not really correct since it should also scale bitmaps in scalable
+    //        fonts but doing that with FreeType is a pain. Since fonts rarely mix
+    //        outlines and bitmaps let's just ignore that for now.
+    fn harfbuzz_scale_factor_for(&self, _glyph: u32) -> I26Dot6 {
+        let is_scalable =
+            unsafe { (*self.ft_face).face_flags & (FT_FACE_FLAG_SCALABLE as FT_Long) != 0 };
+        if is_scalable {
+            I26Dot6::ONE
+        } else {
+            self.size.bitmap_scale
+        }
+    }
+
     fn size_cache_key(&self) -> FontSizeCacheKey {
         FontSizeCacheKey::new(
             self.point_size(),

--- a/src/text/face/tofu.rs
+++ b/src/text/face/tofu.rs
@@ -292,6 +292,10 @@ impl FontImpl for Font {
         self.shared().point_size
     }
 
+    fn harfbuzz_scale_factor_for(&self, _glyph: u32) -> I26Dot6 {
+        I26Dot6::ONE
+    }
+
     fn size_cache_key(&self) -> FontSizeCacheKey {
         FontSizeCacheKey::new(
             self.point_size(),


### PR DESCRIPTION
Fixes https://github.com/afishhh/subrandr/issues/61

Scalable fonts with bitmap glyphs will still have this issue but fixing that requires significantly more effort, so I'll ignore that for now (it may be easier once we switch to `skrifa`).