### PR TITLE
Scale font size used by unitless `line-height` by dpi

### DIFF
--- a/src/layout/inline.rs
+++ b/src/layout/inline.rs
@@ -1438,7 +1438,9 @@ fn layout_run_full(
                         }
                     }
                     LineHeight::Value(value) => {
-                        let computed_font_size = text.font_matcher.size() * 96 / 72;
+                        // (font_size * 96 / 72) * (dpi / 72) simplifies to this
+                        let computed_font_size =
+                            text.font_matcher.size() * text.font_matcher.dpi() as i32 / 54;
                         let metrics = text.primary_font.metrics();
                         let half_leading = ((computed_font_size * value)
                             - (metrics.ascender - metrics.descender))

--- a/src/text/font_match.rs
+++ b/src/text/font_match.rs
@@ -200,6 +200,10 @@ impl<'f> FontMatcher<'f> {
         self.size
     }
 
+    pub fn dpi(&self) -> u32 {
+        self.dpi
+    }
+
     // TODO: Note: it does not matter whether that font actually has a glyph for the space character.
     //       ^^^^ The current implementation might not interact well with font fallback in this regard
     pub fn primary(


### PR DESCRIPTION
Fixes ruby layout placing annotations too high when dpi != 72.