### PR TITLE
C header improvements

### DIFF
--- a/include/logging.h
+++ b/include/logging.h
@@ -33,20 +33,18 @@ typedef uint8_t sbr_log_level;
 //
 // These strings are not null-terminated, the corresponding `_len` argument must
 // be used to avoid overruns. Do not rely on the contents of these strings.
-typedef void (*sbr_log_callback)(
-    sbr_log_level, char const *source, size_t source_len, char const *message,
-    size_t message_len, void *user_data
-);
+typedef void (*sbr_log_callback)(sbr_log_level, char const *source,
+                                 size_t source_len, char const *message,
+                                 size_t message_len, void *user_data);
 
-// Set a callback for subrandr log messages.
+// Set a callback for library log messages.
 //
 // Can only be called before any renderers are created.
 // Note that calling this after a renderer has been created is currently
 // *UNSOUND* even if done in a thread-safe manner.
 // This restriction may be relaxed in the future.
-void sbr_library_set_log_callback(
-    sbr_library *, sbr_log_callback, void *user_data
-);
+void sbr_library_set_log_callback(sbr_library *, sbr_log_callback,
+                                  void *user_data);
 
 #ifdef __cplusplus
 }

--- a/include/subrandr.h
+++ b/include/subrandr.h
@@ -71,10 +71,6 @@ sbr_subtitles *sbr_load_text(sbr_library *, char const *content,
                              size_t content_len, sbr_subtitle_format format,
                              char const *language_hint);
 
-// TODO: Remove this. It shouldn't really exist or at least should
-//       probably have different semantics.
-SBR_UNSTABLE sbr_subtitles *sbr_load_file(sbr_library *, char const *path);
-
 void sbr_subtitles_destroy(sbr_subtitles *);
 
 sbr_renderer *sbr_renderer_create(sbr_library *);

--- a/include/subrandr.h
+++ b/include/subrandr.h
@@ -14,12 +14,14 @@ extern "C" {
 
 #ifdef SBR_ALLOW_UNSTABLE
 #define SBR_UNSTABLE
-#else
+#elif defined(__has_attribute)
+#if __has_attribute(unavailable)
 #define SBR_UNSTABLE                                                           \
   __attribute__((                                                              \
       unavailable("This item is not part of subrandr's stable API yet. "       \
                   "Define SBR_ALLOW_UNSTABLE before including subrandr.h if "  \
                   "you still want to use it.")))
+#endif
 #endif
 
 typedef struct sbr_library sbr_library;
@@ -98,14 +100,18 @@ int sbr_renderer_render(sbr_renderer *, sbr_subtitle_context const *,
 
 void sbr_renderer_destroy(sbr_renderer *);
 
+#ifdef SBR_UNSTABLE
 typedef uint32_t SBR_UNSTABLE sbr_error_code;
 #define SBR_ERR_OTHER (sbr_error_code)1
 #define SBR_ERR_IO (sbr_error_code)2
 #define SBR_ERR_INVALID_ARGUMENT (sbr_error_code)3
 #define SBR_ERR_UNRECOGNIZED_FORMAT (sbr_error_code)10
+#endif
 
 char const *sbr_get_last_error_string(void);
+#ifdef SBR_UNSTABLE
 SBR_UNSTABLE uint32_t sbr_get_last_error_code(void);
+#endif
 
 #undef SBR_UNSTABLE
 


### PR DESCRIPTION
- Removes `sbr_load_file`.
- Improves/adds documentation for a few functions.
- Checks for availability of `__attribute__((unavailable))` for `SBR_UNSTABLE`.