### PR TITLE
Fix panic in bidi reordering of some multi-paragraph text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Improved text decorations to better conform to the `css-2` specification. WebVTT underlines will now be painted after shadows and before the text itself.
 - Fixed incorrect fractional positioning of blurred shadows. This fixes blurred shadows *slightly* jumping around in karaoke subtitles.
 - Fixed software rasterizer not pre-multiplying color values while drawing geometric primitives. Fixes sometimes broken partially transparent backgrounds.
+- Fixed panic in bidi reordering of some multi-paragraph text runs.
 
 ## [v0.2.2]
 

--- a/src/layout/inline.rs
+++ b/src/layout/inline.rs
@@ -1269,13 +1269,10 @@ fn layout_run_full(
 
         let mut visual_runs = Vec::new();
         for paragraph in &bidi.paragraphs {
-            if line_range.start <= paragraph.range.start || line_range.end >= paragraph.range.end {
-                let (_, mut paragraph_runs) = bidi.visual_runs(
-                    paragraph,
-                    line_range.start.max(paragraph.range.start)
-                        ..line_range.end.min(paragraph.range.end),
-                );
-
+            let start = line_range.start.max(paragraph.range.start);
+            let end = line_range.end.min(paragraph.range.end);
+            if start < end {
+                let (_, mut paragraph_runs) = bidi.visual_runs(paragraph, start..end);
                 visual_runs.append(&mut paragraph_runs);
             }
         }


### PR DESCRIPTION
Random arabic subtitles strike again...

Changed a nonsensical condition into a more believable condition instead.