### PR TITLE
Correctly handle `seen_cue` in WebVTT parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed software rasterizer not pre-multiplying color values while drawing geometric primitives. Fixes sometimes broken partially transparent backgrounds.
 - Fixed panic in bidi reordering of some multi-paragraph text runs.
 - Implemented srv3 underline support.
+- Made WebVTT parser correctly ignore STYLE and REGION blocks following the first cue.
 
 ## [v0.2.2]
 


### PR DESCRIPTION
Now the parser correctly ignores STYLE and REGION blocks after the first cue.