### PR TITLE
Simplify outline representation

### DIFF
--- a/sbr-util/src/math.rs
+++ b/sbr-util/src/math.rs
@@ -13,7 +13,7 @@ pub use num::*;
 mod outline;
 pub use outline::*;
 
-#[derive(Clone, Copy, Default, PartialEq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
 #[repr(C)]
 pub struct Point2<N> {
     pub x: N,
@@ -52,7 +52,7 @@ impl<N: Debug> Debug for Point2<N> {
     }
 }
 
-#[derive(Clone, Copy, Default, PartialEq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, Hash)]
 #[repr(C)]
 pub struct Vec2<N> {
     pub x: N,

--- a/sbr-util/src/math/curve.rs
+++ b/sbr-util/src/math/curve.rs
@@ -181,17 +181,6 @@ impl CubicBezier<f32> {
         flatten::cubic_to_quadratics(self, tolerance)
     }
 
-    // FIXME: This function probably shouldn't exist as the tolerance for
-    //        `cubic_to_quadratics` and `flatten_quadratic` should be separate.
-    //        Currently this is not used in any code paths so could be removed if
-    //        the debugging utility of `Outline::flatten_contour` is deemed not
-    //        important enough.
-    pub fn flatten_into(&self, tolerance: f32, out: &mut Vec<Point2f>) {
-        for quadratic in self.to_quadratics(tolerance) {
-            out.extend(quadratic.flatten(tolerance))
-        }
-    }
-
     pub fn from_b_spline(b0: Point2f, b1: Point2f, b2: Point2f, b3: Point2f) -> Self {
         Self([
             ((b0.to_vec() + b1.to_vec() * 4.0 + b2.to_vec()) / 6.0).to_point(),

--- a/sbr-util/src/math/outline.rs
+++ b/sbr-util/src/math/outline.rs
@@ -1,309 +1,201 @@
-use std::fmt::Debug;
-
 use super::*;
-use crate::fmt_from_fn;
 
-pub struct OutlineBuilder {
-    outline: Outline,
-    first_point_of_contour: usize,
-    segment_start: u32,
-}
+pub trait Outline<N: Number> {
+    fn iter(&self) -> impl Iterator<Item = OutlineEvent<N>>;
 
-impl OutlineBuilder {
-    pub const fn new() -> Self {
-        Self {
-            outline: Outline::empty(),
-            first_point_of_contour: 0,
-            segment_start: 0,
-        }
+    fn control_box(&self) -> Rect2<N> {
+        self.iter().fold(Rect2::NOTHING, |mut r, e| {
+            match e {
+                OutlineEvent::MoveTo(p) => r.expand_to_point(p),
+                OutlineEvent::LineTo(end) => r.expand_to_point(end),
+                OutlineEvent::QuadTo(c0, end) => {
+                    r.expand_to_point(c0);
+                    r.expand_to_point(end);
+                }
+                OutlineEvent::CubicTo(c0, c1, end) => {
+                    r.expand_to_point(c0);
+                    r.expand_to_point(c1);
+                    r.expand_to_point(end);
+                }
+            };
+            r
+        })
     }
-
-    #[inline(always)]
-    pub fn points(&self) -> &[Point2f] {
-        self.outline.points()
-    }
-
-    #[inline]
-    pub fn move_to(&mut self, point: Point2f) {
-        self.close_contour_with_line();
-        self.add_point(point);
-    }
-
-    #[inline]
-    pub fn line_to(&mut self, point: Point2f) {
-        self.add_point(point);
-        self.add_segment(SegmentDegree::Linear);
-    }
-
-    #[inline]
-    pub fn quad_to(&mut self, control: Point2f, point: Point2f) {
-        self.add_point(control);
-        self.add_point(point);
-        self.add_segment(SegmentDegree::Quadratic);
-    }
-
-    #[inline]
-    pub fn cubic_to(&mut self, control1: Point2f, control2: Point2f, point: Point2f) {
-        self.add_point(control1);
-        self.add_point(control2);
-        self.add_point(point);
-        self.add_segment(SegmentDegree::Cubic);
-    }
-
-    #[inline]
-    pub fn contour_points_mut(&mut self) -> &mut [Point2f] {
-        &mut self.outline.points[self.first_point_of_contour..]
-    }
-
-    #[inline]
-    pub fn is_closed(&self) -> bool {
-        self.outline
-            .segments
-            .last()
-            .is_none_or(Segment::end_of_contour)
-    }
-
-    #[inline]
-    pub fn add_point(&mut self, point: Point2f) {
-        self.outline.points.push(point)
-    }
-
-    #[inline]
-    pub fn add_segment(&mut self, degree: SegmentDegree) {
-        self.outline.segments.push(Segment {
-            degree,
-            end_of_contour: false,
-            start: self.segment_start,
-        });
-        self.segment_start += degree as u32;
-    }
-
-    fn close_contour_with_line(&mut self) {
-        if let Some(&last) = self.outline.points.last() {
-            if self.outline.segments.last_mut().unwrap().end_of_contour {
-                return;
-            }
-
-            let first = self.outline.points[self.first_point_of_contour];
-            if last == first {
-                self.outline.segments.last_mut().unwrap().end_of_contour = true;
-                self.segment_start += 1;
-                self.first_point_of_contour = self.outline.points.len();
-            } else {
-                self.add_segment(SegmentDegree::Linear);
-                self.close_contour();
-            }
-        }
-    }
-
-    pub fn close_contour(&mut self) {
-        self.outline.segments.last_mut().unwrap().end_of_contour = true;
-        self.outline
-            .points
-            .push(self.outline.points[self.first_point_of_contour]);
-        self.segment_start += 1;
-        self.first_point_of_contour = self.outline.points.len();
-    }
-
-    pub fn build(mut self) -> Outline {
-        self.close_contour_with_line();
-
-        let expected = self.segment_start;
-        if self.outline.points.len() != expected as usize {
-            panic!(
-                "Invalid outline: Incorrect number of points: expected {} found {}\npoints: {:?}\nsegments: {:?}",
-                expected, self.outline.points.len(),
-                self.outline.points, self.outline.segments
-            );
-        }
-
-        if !self.is_closed() {
-            panic!("Invalid outline: Last segment is not marked end of contour")
-        }
-
-        self.outline
-    }
-}
-
-impl Default for OutlineBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SegmentDegree {
-    Linear = 1,
-    Quadratic = 2,
-    Cubic = 3,
-}
-
-#[derive(Debug, Clone)]
-pub enum SegmentCurve {
-    Linear([Point2f; 2]),
-    Quadratic(QuadraticBezier<f32>),
-    Cubic(CubicBezier<f32>),
 }
 
 #[derive(Debug, Clone, Copy)]
-#[repr(Rust, packed(8))]
-pub struct Segment {
-    end_of_contour: bool,
-    degree: SegmentDegree,
-    start: u32,
+#[allow(clippy::enum_variant_names)]
+pub enum OutlineEvent<N> {
+    MoveTo(Point2<N>),
+    LineTo(Point2<N>),
+    QuadTo(Point2<N>, Point2<N>),
+    CubicTo(Point2<N>, Point2<N>, Point2<N>),
 }
 
-impl Segment {
-    #[inline(always)]
-    pub const fn degree(&self) -> SegmentDegree {
-        self.degree
-    }
-
-    #[inline(always)]
-    pub const fn end_of_contour(&self) -> bool {
-        self.end_of_contour
-    }
-}
-
-#[derive(Clone)]
-pub struct Outline {
-    points: Vec<Point2f>,
-    segments: Vec<Segment>,
-}
-
-impl Outline {
-    pub const fn empty() -> Self {
-        Self {
-            points: Vec::new(),
-            segments: Vec::new(),
+impl<N> OutlineEvent<N> {
+    pub fn map<M>(self, mut mapper: impl FnMut(Point2<N>) -> Point2<M>) -> OutlineEvent<M> {
+        match self {
+            Self::MoveTo(point) => OutlineEvent::MoveTo(mapper(point)),
+            Self::LineTo(end) => OutlineEvent::LineTo(mapper(end)),
+            Self::QuadTo(c0, end) => OutlineEvent::QuadTo(mapper(c0), mapper(end)),
+            Self::CubicTo(c0, c1, end) => {
+                OutlineEvent::CubicTo(mapper(c0), mapper(c1), mapper(end))
+            }
         }
-    }
-
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.segments.is_empty()
-    }
-
-    #[inline]
-    pub fn segments(&self) -> &[Segment] {
-        &self.segments
-    }
-
-    #[inline]
-    pub fn points_for_segment(&self, s: Segment) -> &[Point2f] {
-        let start = s.start as usize;
-        &self.points[start..(start + s.degree as usize + 1)]
-    }
-
-    #[inline]
-    pub fn curve_for_segment(&self, s: &Segment) -> SegmentCurve {
-        let start = s.start as usize;
-        match s.degree {
-            SegmentDegree::Linear => SegmentCurve::Linear(
-                <[Point2f; 2]>::try_from(&self.points[start..start + 2]).unwrap(),
-            ),
-            SegmentDegree::Quadratic => SegmentCurve::Quadratic(QuadraticBezier(
-                <[Point2f; 3]>::try_from(&self.points[start..start + 3]).unwrap(),
-            )),
-            SegmentDegree::Cubic => SegmentCurve::Cubic(CubicBezier(
-                <[Point2f; 4]>::try_from(&self.points[start..start + 4]).unwrap(),
-            )),
-        }
-    }
-
-    #[inline]
-    pub fn points(&self) -> &[Point2f] {
-        &self.points
-    }
-
-    fn evaluate_segment_normalized(&self, i: usize, t: f32) -> Point2f {
-        assert!((0.0..=1.0).contains(&t));
-
-        let value = evaluate_bezier(self.points_for_segment(self.segments[i]), t);
-        value
-    }
-
-    pub fn evaluate_segment(&self, segment: Segment, t: f32) -> Point2f {
-        assert!((0.0..=1.0).contains(&t));
-
-        let value = evaluate_bezier(self.points_for_segment(segment), t);
-        value
-    }
-
-    #[inline(always)]
-    pub fn evaluate(&self, t: f32) -> Point2f {
-        self.evaluate_segment_normalized(t.trunc() as usize, t.fract())
-    }
-
-    pub fn control_box(&self) -> Rect2f {
-        Rect2f::bounding_box_of_points(self.points.iter().copied())
-    }
-
-    pub fn scale(&mut self, xy: f32) {
-        for p in self.points.iter_mut() {
-            *p = (p.to_vec() * xy).to_point()
-        }
-    }
-
-    /// Does not include the first point of the segment in the flattened version
-    pub fn flatten_segment(&self, segment: Segment, tolerance: f32, out: &mut Vec<Point2f>) {
-        let points = self.points_for_segment(segment);
-        match points.len() {
-            2 => out.push(points[1]),
-            3 => QuadraticBezier::from_ref(points.try_into().unwrap()).flatten_into(tolerance, out),
-            4 => CubicBezier::from_ref(points.try_into().unwrap()).flatten_into(tolerance, out),
-            _ => unreachable!(),
-        }
-    }
-
-    pub fn iter_contours(&self) -> impl Iterator<Item = &[Segment]> + use<'_> {
-        let mut it = self
-            .segments
-            .iter()
-            .copied()
-            .enumerate()
-            .filter_map(|(i, s)| if s.end_of_contour { Some(i) } else { None });
-
-        let mut last = 0;
-        std::iter::from_fn(move || {
-            it.next().map(|end_of_contour| {
-                let segments = &self.segments[last..=end_of_contour];
-                last = end_of_contour + 1;
-                segments
-            })
-        })
-    }
-
-    pub fn flatten_contour(&self, segments: &[Segment]) -> Vec<Point2f> {
-        let mut polyline = vec![self.points_for_segment(segments[0])[0]];
-        for segment in segments {
-            self.flatten_segment(*segment, 0.2, &mut polyline);
-        }
-        polyline
     }
 }
 
-impl Debug for Outline {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Outline ")?;
-        let mut list = f.debug_list();
-        for segments in self.iter_contours() {
-            list.entry(&fmt_from_fn(|f| {
-                write!(f, "Contour ")?;
+pub trait OutlineIterExt<N: Number>: Iterator<Item = OutlineEvent<N>> {
+    fn map_points<M: Number>(
+        self,
+        mut mapper: impl FnMut(Point2<N>) -> Point2<M>,
+    ) -> impl Iterator<Item = OutlineEvent<M>>
+    where
+        Self: Sized,
+    {
+        self.map(move |event| event.map(&mut mapper))
+    }
+}
 
-                let mut list = f.debug_list();
-                for segment in segments.iter().copied() {
-                    let points = self.points_for_segment(segment);
-                    list.entry(&fmt_from_fn(|f| {
-                        f.debug_struct("Curve")
-                            .field("degree", &segment.degree)
-                            .field("points", &points)
-                            .finish()
-                    }));
+impl<N: Number, I: Iterator<Item = OutlineEvent<N>>> OutlineIterExt<N> for I {}
+
+pub trait FloatOutlineIterExt: Iterator<Item = OutlineEvent<f32>> + Sized {
+    // This is a pain to make a real iterator with the current non-owned flattenning APIs.
+    fn visit_flattened_with(
+        self,
+        mut callback: impl FnMut(Point2<f32>, Point2<f32>),
+        quadratic_flatten_tolerance: f32,
+        cubic_reduction_tolerance: f32,
+    ) {
+        let mut previous = Point2::ZERO;
+        for event in self {
+            match event {
+                OutlineEvent::MoveTo(point) => previous = point,
+                OutlineEvent::LineTo(end) => {
+                    callback(previous, end);
+                    previous = end;
                 }
-                list.finish()
-            }));
+                OutlineEvent::QuadTo(c0, end) => {
+                    for next in
+                        QuadraticBezier([previous, c0, end]).flatten(quadratic_flatten_tolerance)
+                    {
+                        callback(previous, next);
+                        previous = next;
+                    }
+                }
+                OutlineEvent::CubicTo(c0, c1, end) => {
+                    for q in CubicBezier([previous, c0, c1, end])
+                        .to_quadratics(cubic_reduction_tolerance)
+                    {
+                        for next in q.flatten(quadratic_flatten_tolerance) {
+                            callback(previous, next);
+                            previous = next;
+                        }
+                    }
+                }
+            }
         }
-        list.finish()
     }
+}
+
+impl<I: Iterator<Item = OutlineEvent<f32>>> FloatOutlineIterExt for I {}
+
+pub struct StaticOutline<N: Number + 'static> {
+    #[doc(hidden)]
+    pub _control_box: Rect2<N>,
+    #[doc(hidden)]
+    pub _events: &'static [OutlineEvent<N>],
+}
+
+impl<N: Number> Outline<N> for StaticOutline<N> {
+    fn iter(&self) -> impl Iterator<Item = OutlineEvent<N>> {
+        self._events.iter().copied()
+    }
+
+    fn control_box(&self) -> Rect2<N> {
+        self._control_box
+    }
+}
+
+#[macro_export]
+macro_rules! make_static_outline {
+    {
+        $(# $($command: ident $(($x: literal, $y: literal)),+;)*)*
+    } => {{
+        $crate::math::StaticOutline::<f32> {
+            _control_box: const {
+                let mut bbox = $crate::math::Rect2::<f32>::NOTHING;
+                $($($(
+                    {
+                        let point = $crate::math::Point2::new($x as f32, $y as f32);
+                        bbox.min.x = bbox.min.x.min(point.x);
+                        bbox.min.y = bbox.min.y.min(point.y);
+                        bbox.max.x = bbox.max.x.max(point.x);
+                        bbox.max.y = bbox.max.y.max(point.y);
+                    }
+                )*)*)*
+                bbox
+            },
+            _events: &const {
+                const N_EVENTS: usize =
+                    0 $(+ $crate::make_static_outline!(
+                        @contour_length(result)
+                        $($command $($crate::math::Point2::new($x as f32, $y as f32)),+;)*
+                    ))*;
+                let mut array = [$crate::math::OutlineEvent::MoveTo($crate::math::Point2::ZERO); N_EVENTS];
+                let mut i = 0;
+
+                $($crate::make_static_outline!(
+                    @contour(array, i)
+                    $($command $($crate::math::Point2::new($x as f32, $y as f32)),+;)*
+                );)*
+
+                assert!(i == N_EVENTS);
+                array
+            }
+        }
+    }};
+
+    (@contour_length($result: ident) move_to $first: expr; $($command: ident $($p: expr),+;)*) => {
+        1
+            $(+ $crate::make_static_outline!(@count_command $command $($p),*))*
+            + $crate::make_static_outline!(@count_close_contour($first) $($($p),*),*)
+    };
+    (@count_command $($anything: tt)*) => { 1 };
+    (@count_close_contour($first: expr) $next: expr, $($rest: tt)*) => {
+        $crate::make_static_outline!(@count_close_contour($first) $($rest)*);
+    };
+    (@count_close_contour($first: expr) $last: expr) => {
+        if const { $first.x != $last.x || $first.y != $last.y } { 1 } else { 0 }
+    };
+
+
+    (@contour($result: ident, $i: ident) move_to $first: expr; $($command: ident $($p: expr),+;)*) => {
+        $result[$i] = $crate::math::OutlineEvent::MoveTo($first);
+        $i += 1;
+        $(
+            $result[$i] = $crate::make_static_outline!(@instruction $command $($p),*);
+            $i += 1;
+        )*
+        $crate::make_static_outline!(@close_contour($result, $i, $first) $($($p),*),*)
+    };
+    (@close_contour($result: ident, $i: ident, $first: expr) $next: expr, $($rest: tt)*) => {
+        $crate::make_static_outline!(@close_contour($result, $i, $first) $($rest)*);
+    };
+    (@close_contour($result: ident, $i: ident, $first: expr) $last: expr) => {
+        if const { $first.x != $last.x || $first.y != $last.y } {
+            $result[$i] = $crate::math::OutlineEvent::LineTo($first);
+            $i += 1;
+        }
+    };
+
+    (@instruction line_to $end: expr) => {
+        $crate::math::OutlineEvent::LineTo($end)
+    };
+    (@instruction quad_to $c0: expr, $end: expr) => {
+        $crate::math::OutlineEvent::QuadTo($c0, $end)
+    };
+    (@instruction cubic_to $c0: expr, $c1: expr, $end: expr) => {
+        $crate::math::OutlineEvent::CubicTo($c0, $c1, $end)
+    };
 }

--- a/src/text/face/freetype.rs
+++ b/src/text/face/freetype.rs
@@ -10,7 +10,7 @@ use std::{
 use rasterize::{PixelFormat, Rasterizer};
 use text_sys::*;
 use thiserror::Error;
-use util::math::{I16Dot16, I26Dot6, Outline, OutlineBuilder, Point2f, SegmentDegree, Vec2};
+use util::math::{I16Dot16, I26Dot6, Vec2};
 
 use super::{Axis, FaceImpl, FontImpl, FontMetrics, GlyphMetrics, OpenTypeTag, SingleGlyphBitmap};
 use crate::text::{ft_utils::*, FontSizeCacheKey};
@@ -565,28 +565,6 @@ impl Font {
     ) -> Result<(FT_Face, *mut hb_font_t), FreeTypeError> {
         Ok((self.with_applied_size()?, self.hb_font))
     }
-
-    /// Gets the Outline associated with the glyph at `index`.
-    ///
-    /// Returns [`None`] if the glyph does not exist in this font, or it is not
-    /// an outline glyph.
-    // FIXME: This is an unused function but rustc doesn't think so anymore?
-    #[allow(dead_code)]
-    pub fn glyph_outline(&self, index: u32) -> Result<Option<Outline>, FreeTypeError> {
-        let face = self.with_applied_size()?;
-        unsafe {
-            // According to FreeType documentation, bitmap-only fonts ignore
-            // FT_LOAD_NO_BITMAP.
-            if ((*face).face_flags & FT_FACE_FLAG_SCALABLE as FT_Long) == 0 {
-                return Ok(None);
-            }
-
-            // TODO: return none if the glyph does not exist in the font
-            fttry!(FT_Load_Glyph(face, index, FT_LOAD_NO_BITMAP as i32))?;
-
-            Ok(Some(outline_from_freetype(&(*(*face).glyph).outline)))
-        }
-    }
 }
 
 impl std::fmt::Debug for Font {
@@ -960,82 +938,4 @@ fn copy_font_bitmap<const PIXEL_MODE: u8>(
             });
         }
     }
-}
-
-unsafe fn outline_from_freetype(ft: &FT_Outline) -> Outline {
-    let mut first = 0;
-    let mut builder = OutlineBuilder::new();
-    let contours = std::slice::from_raw_parts(ft.contours, ft.n_contours as usize);
-    let points = std::slice::from_raw_parts(ft.points, ft.n_points as usize);
-    let tags = std::slice::from_raw_parts(ft.tags, ft.n_points as usize);
-
-    // TODO: Convert FT_CURVE_TAG* to u8 in text-sys
-    for last in contours.iter().map(|&x| x as usize) {
-        // FT_Pos in FT_Outline seems to be 26.6
-        let to_point = |vec: FT_Vector| {
-            Point2f::new(
-                vec.x as f32 * 2.0f32.powi(-6),
-                -vec.y as f32 * 2.0f32.powi(-6),
-            )
-        };
-
-        let midpoint = |a: Point2f, b: Point2f| Point2f::new((a.x + b.x) / 2.0, (a.y + b.y) / 2.0);
-
-        let mut last_tag;
-        let mut final_degree = SegmentDegree::Linear;
-        let mut add_range = first..last + 1;
-        if (tags[first] & 0b11) != FT_CURVE_TAG_ON as u8 {
-            if (tags[last] & 0b11) == FT_CURVE_TAG_CONIC as u8 {
-                builder.add_point(midpoint(to_point(points[first]), to_point(points[last])));
-                last_tag = FT_CURVE_TAG_ON as u8;
-                final_degree = SegmentDegree::Quadratic;
-            } else {
-                assert_eq!(tags[last] & 0b11, FT_CURVE_TAG_ON as u8);
-                builder.add_point(to_point(points[last]));
-                last_tag = tags[last] & 0b11;
-                add_range.end -= 1;
-            }
-        } else {
-            builder.add_point(to_point(points[first]));
-            last_tag = tags[first] & 0b11;
-            add_range.start += 1;
-            if tags[last] & 0b11 == FT_CURVE_TAG_CUBIC as u8 {
-                final_degree = SegmentDegree::Cubic;
-            } else if tags[last] & 0b11 == FT_CURVE_TAG_CONIC as u8 {
-                final_degree = SegmentDegree::Quadratic;
-            }
-        }
-
-        for (&point, &tag) in points[add_range.clone()].iter().zip(tags[add_range].iter()) {
-            let tag = tag & 0b11;
-            let point = to_point(point);
-
-            if tag == FT_CURVE_TAG_ON as u8 {
-                if last_tag == FT_CURVE_TAG_ON as u8 {
-                    builder.add_segment(SegmentDegree::Linear);
-                } else if last_tag == FT_CURVE_TAG_CONIC as u8 {
-                    builder.add_segment(SegmentDegree::Quadratic);
-                } else {
-                    builder.add_segment(SegmentDegree::Cubic);
-                }
-            }
-
-            if tag == FT_CURVE_TAG_CONIC as u8 && last_tag == FT_CURVE_TAG_CONIC as u8 {
-                let last = *builder.points().last().unwrap();
-                builder.add_point(midpoint(last, point));
-                builder.add_segment(SegmentDegree::Quadratic);
-            }
-
-            last_tag = tag;
-            builder.add_point(point);
-        }
-
-        builder.add_segment(final_degree);
-        builder.close_contour();
-        first = last + 1;
-    }
-
-    assert_eq!(first, points.len());
-
-    builder.build()
 }


### PR DESCRIPTION
Also removed some dead code (That I did update and will keep in a branch until it is needed again).

I'm still not perfectly happy about this but it's functional, gets rid of the `Outline` struct, and as a bonus makes the tofu outlines allocated fully statically.