### PR TITLE
Simplify blitting functions

### DIFF
--- a/sbr-rasterize/src/rasterizer.rs
+++ b/sbr-rasterize/src/rasterizer.rs
@@ -235,12 +235,7 @@ pub trait Rasterizer {
     /// Blits `texture` onto `target` at (`dx`, `dy`).
     ///
     /// `target` must be a monochrome render texture and `texture` must be a monochrome texture.
-    ///
-    /// # Safety
-    ///
-    /// Blitting `texture` onto `target` at the specified coordinates (`dx`, `dy`) must not
-    /// result in out-of-bounds accesses on either `texture` or `target`.
-    unsafe fn blit_to_mono_texture_unchecked(
+    fn blit_to_mono_texture(
         &mut self,
         target: &mut RenderTarget,
         dx: i32,

--- a/sbr-rasterize/src/rasterizer/sw/blur.rs
+++ b/sbr-rasterize/src/rasterizer/sw/blur.rs
@@ -1,6 +1,4 @@
-use std::{f32::consts::PI, mem::MaybeUninit, ops::Range};
-
-use crate::color::BGRA8;
+use std::{f32::consts::PI, mem::MaybeUninit};
 
 pub fn gaussian_sigma_to_box_radius(sigma: f32) -> usize {
     // https://drafts.fxtf.org/filter-effects/#funcdef-filter-blur
@@ -82,48 +80,6 @@ impl Blurer {
         self.iextent = ((radius * 2 + 1) as f32).recip();
     }
 
-    pub unsafe fn buffer_blit_bgra8_unchecked(
-        &mut self,
-        dx: i32,
-        dy: i32,
-        source: &[BGRA8],
-        xs: Range<usize>,
-        ys: Range<usize>,
-        stride: usize,
-    ) {
-        for sy in ys {
-            let mut di = (self.width as i32 * (dy + sy as i32) + dx) as usize;
-            for sx in xs.clone() {
-                let si = sy * stride + sx;
-                unsafe {
-                    *self.front.get_unchecked_mut(di) = source.get_unchecked(si).a as f32 / 255.0;
-                }
-                di += 1;
-            }
-        }
-    }
-
-    pub unsafe fn buffer_blit_mono8_unchecked(
-        &mut self,
-        dx: i32,
-        dy: i32,
-        source: &[u8],
-        xs: Range<usize>,
-        ys: Range<usize>,
-        stride: usize,
-    ) {
-        for sy in ys {
-            let mut di = (self.width as i32 * (dy + sy as i32) + dx) as usize;
-            for sx in xs.clone() {
-                let si = sy * stride + sx;
-                unsafe {
-                    *self.front.get_unchecked_mut(di) = *source.get_unchecked(si) as f32 / 255.0;
-                }
-                di += 1;
-            }
-        }
-    }
-
     unsafe fn swap_buffers(&mut self) {
         let (front_ptr, front_len, front_capacity) = util::vec_parts(&mut self.front);
         let (back_ptr, back_len, back_capacity) = util::vec_parts(&mut self.back);
@@ -177,6 +133,10 @@ impl Blurer {
 
     pub fn front(&self) -> &[f32] {
         &self.front
+    }
+
+    pub fn front_mut(&mut self) -> &mut [f32] {
+        &mut self.front
     }
 
     pub fn padding(&self) -> usize {

--- a/sbr-rasterize/src/rasterizer/wgpu.rs
+++ b/sbr-rasterize/src/rasterizer/wgpu.rs
@@ -1002,7 +1002,7 @@ impl super::Rasterizer for Rasterizer {
         }
     }
 
-    unsafe fn blit_to_mono_texture_unchecked(
+    fn blit_to_mono_texture(
         &mut self,
         target: &mut super::RenderTarget,
         dx: i32,

--- a/src/text.rs
+++ b/src/text.rs
@@ -297,14 +297,12 @@ impl MonochromeImage {
         let mut target = rasterizer.create_mono_texture_rendered(width, height);
 
         for glyph in &image.glyphs {
-            unsafe {
-                rasterizer.blit_to_mono_texture_unchecked(
-                    &mut target,
-                    glyph.offset.0 - offset.x,
-                    glyph.offset.1 - offset.y,
-                    &glyph.texture,
-                );
-            }
+            rasterizer.blit_to_mono_texture(
+                &mut target,
+                glyph.offset.0 - offset.x,
+                glyph.offset.1 - offset.y,
+                &glyph.texture,
+            );
         }
 
         MonochromeImage {


### PR DESCRIPTION
Does what it says on the tin, also makes `blit_to_mono_texture` safe and cleans up `Blurer` front buffer blitting.