### PR TITLE
Simplify `Cache` implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,6 +1792,9 @@ dependencies = [
 [[package]]
 name = "sbr-util"
 version = "0.2.2"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "scopeguard"

--- a/sbr-util/Cargo.toml
+++ b/sbr-util/Cargo.toml
@@ -5,3 +5,6 @@ edition.workspace = true
 
 [lints]
 workspace = true
+
+[dependencies]
+hashbrown = { version = "0.15", default-features = false }

--- a/src/text/glyph_cache.rs
+++ b/src/text/glyph_cache.rs
@@ -11,7 +11,7 @@ use crate::text::Face;
 const CACHE_CONFIGURATION: CacheConfiguration = CacheConfiguration {
     // Trim the cache once it reaches 8MiB approximate memory footprint.
     trim_memory_threshold: 8 * 1024 * 1024,
-    // Keep the last two cache generations while trimming.
+    // Keep the last three cache generations while trimming.
     trim_kept_generations: 3,
 };
 


### PR DESCRIPTION
Adds one (1) dependency on a library (hashbrown) that the *standard library* already depends on anyway.