### PR TITLE
Don't emit invalid rectangles as output pieces

### DIFF
--- a/src/raster.rs
+++ b/src/raster.rs
@@ -236,6 +236,10 @@ pub fn rasterize_to_pieces(
                 }
             }
             PaintOp::Rect(fill) => {
+                if fill.rect.is_empty() {
+                    continue;
+                }
+
                 on_piece(OutputPiece {
                     pos: Point2::new(
                         fill.rect.min.x.floor_to_inner(),


### PR DESCRIPTION
Fixes https://github.com/afishhh/subrandr/issues/115

Not sure where a rectangle with a negative size is emitted (`-1` width!) but let's not underflow our casts because of it.
Bitmap output pieces may still be zero sized but that shouldn't cause issues and is something I will fix when reworking this stuff in a later iteration of https://github.com/afishhh/subrandr/pull/112.