### PR TITLE
Add version macros to `subrandr.h` header

### DIFF
--- a/ci/c_sanity_check.c
+++ b/ci/c_sanity_check.c
@@ -1,16 +1,22 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#include "subrandr/logging.h"
 #include "subrandr/subrandr.h"
 
 int main() {
   uint32_t a, b, c;
   sbr_library_version(&a, &b, &c);
-  printf("subrandr v%u.%u.%u\n", a, b, c);
+  printf("subrandr runtime version: v%u.%u.%u\n", a, b, c);
+  printf("subrandr header version: v%u.%u.%u\n", SUBRANDR_MAJOR, SUBRANDR_MINOR,
+         SUBRANDR_PATCH);
 
   sbr_library *lib = sbr_library_init();
   sbr_renderer *r = sbr_renderer_create(lib);
   printf("renderer %p created\n", r);
   sbr_renderer_destroy(r);
   sbr_library_fini(lib);
+
+  // so logging.h is used and we can ensure its presence
+  (void)SBR_LOG_LEVEL_DEBUG;
 }

--- a/include/subrandr.h
+++ b/include/subrandr.h
@@ -28,6 +28,10 @@ extern "C" {
 #endif
 #endif
 
+#define SUBRANDR_MAJOR SUBRANDR_MAJOR_PLACEHOLDER
+#define SUBRANDR_MINOR SUBRANDR_MINOR_PLACEHOLDER
+#define SUBRANDR_PATCH SUBRANDR_PATCH_PLACEHOLDER
+
 typedef int32_t sbr_26dot6;
 typedef uint32_t sbr_bgra8;
 


### PR DESCRIPTION
Last minute change for release because not having version macros since 1.0.0 seems like it could conceivably cause some inconvenience.