### PR TITLE
Fix UB in `blit_generic_unchecked` pointer operations

### DIFF
--- a/sbr-rasterize/src/rasterizer/sw/blit.rs
+++ b/sbr-rasterize/src/rasterizer/sw/blit.rs
@@ -12,7 +12,9 @@ unsafe fn blit_generic_unchecked<S: Copy, D: Copy>(
     height: usize,
     process: impl Fn(S, &mut D),
 ) {
-    let src_end = src.add(src_stride * height);
+    // NOTE: These `add`s have to be `wrapping_add`s because they can
+    //       go out-of-bounds of the underlying allocations if `dx > 0`.
+    let src_end = src.wrapping_add(src_stride * height);
     let dst_row_step = dst_stride - width;
     let src_row_step = src_stride - width;
 
@@ -26,8 +28,8 @@ unsafe fn blit_generic_unchecked<S: Copy, D: Copy>(
             src = src.add(1);
             dst = dst.add(1);
         }
-        src = src.add(src_row_step);
-        dst = dst.add(dst_row_step);
+        src = src.wrapping_add(src_row_step);
+        dst = dst.wrapping_add(dst_row_step);
     }
 }
 

--- a/sbr-rasterize/src/rasterizer/sw/scale.rs
+++ b/sbr-rasterize/src/rasterizer/sw/scale.rs
@@ -85,7 +85,7 @@ unsafe fn scale_generic<W: WrapMode, S: Copy, D: Copy>(
     src_size: Vec2<i32>,
     process: impl Fn(LinearSamples<S>, &mut D),
 ) {
-    let dst_end = dst.add(dst_stride * dst_height);
+    let dst_end = dst.wrapping_add(dst_stride * dst_height);
     let dst_row_step = dst_stride - dst_width;
     let dx = I16Dot16::from_quotient(src_size.x, dst_width as i32);
     let dy = I16Dot16::from_quotient(src_size.y, dst_height as i32);
@@ -117,7 +117,7 @@ unsafe fn scale_generic<W: WrapMode, S: Copy, D: Copy>(
             dst = dst.add(1);
         }
         src_y += dy;
-        dst = dst.add(dst_row_step);
+        dst = dst.wrapping_add(dst_row_step);
     }
 }
 


### PR DESCRIPTION
Found by running miri on the tests added by https://github.com/afishhh/subrandr/pull/128.

Note that this UB wasn't very impactful since it was of the "compiler can do technically weird stuff" kind.

Also applied the same to `scale_generic` although that wasn't susceptible in the usual case that the whole `stride * height` of the target buffer is allocated (the only way it was used).