### PR TITLE
Add option-based configuration API

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -103,6 +103,33 @@ Overrides the default edge color (`ec` attribute) of SRV3 pens.
 
 If `none`, the edge color is not defined and edge decorations will use the fallback color calculations described in `srv3-edge-type` above.
 
+### srv3-default-win-align
+
+<table>
+  <tr><td><i>Default</td> <td>7</td></tr>
+  <tr><td><i>Grammar</td> <td>&lt;integer [0,8]&gt;</td></tr>
+</table>
+
+Overrides the default alignment (`ap` attribute of `wp`) of SRV3 windows.  
+
+### srv3-default-win-x
+
+<table>
+  <tr><td><i>Default</td> <td>50</td></tr>
+  <tr><td><i>Grammar</td> <td>&lt;integer [0,100]&gt;</td></tr>
+</table>
+
+Overrides the default x position (`ah` attribute of `wp`) of SRV3 windows.  
+
+### srv3-default-win-y
+
+<table>
+  <tr><td><i>Default</td> <td>100</td></tr>
+  <tr><td><i>Grammar</td> <td>&lt;integer [0,100]&gt;</td></tr>
+</table>
+
+Overrides the default y position (`av` attribute of `wp`) of SRV3 windows.  
+
 ## Testing/debugging options
 
 Options meant to be used while working on subrandr or diagnosing issues.

--- a/docs/options.md
+++ b/docs/options.md
@@ -9,6 +9,15 @@ Value grammar is defined using [CSS Value Definition Syntax](https://www.w3.org/
 - The values are *not* parsed like real CSS Values, but the intention is that this will be changed in the future.
 - 3 and 4 character hex colors are not supported yet.
 
+## API stability
+
+> [!NOTE]
+> The stability guarantees of these options are purposefully vague because it is not clear how volatile they will really be in practice. Maybe I won't change them for years in which case the guarantees can be strengthened.
+
+Changes to options not explicitly specified as unstable have best-effort stablility guarantees across API-compatible versions.
+They may still be renamed, removed, or have their syntax changed but new versions will still try to accept old names/syntax (unless an option is removed with no replacement).
+Such translation functionality may or may not be removed after a long enough time.
+
 ## SRV3-specific options
 
 ### srv3-layout-mode

--- a/docs/options.md
+++ b/docs/options.md
@@ -1,0 +1,129 @@
+subrandr supports various customization options that change how subtitles are rendered or provide functionality helpful for debugging.
+
+In the C API, options can be set using the interface exposed by the `subrandr/config.h` header.  
+For information on setting them in a particular program that uses subrandr, consult its documentation. Individual programs can provide their own interface that wraps subrandr's options, in which case you might need to read the documentation for that interface instead of this document.   
+Defaults can be overridden process-wide by setting the `SBR_CONFIG` environment variable but this is intended as a debugging escape hatch and may be removed/changed in API-compatible releases.
+
+Value grammar is defined using [CSS Value Definition Syntax](https://www.w3.org/TR/css-values-3/#value-defs) with the following caveats:
+- Bracketed range notation is also used below to specify non-range restrictions.
+- The values are *not* parsed like real CSS Values, but the intention is that this will be changed in the future.
+- 3 and 4 character hex colors are not supported yet.
+
+## SRV3-specific options
+
+### srv3-layout-mode
+
+<table>
+  <tr><td><i>Default</td> <td>inline-block</td></tr>
+  <tr><td><i>Grammar</td> <td>inline-block | inline</td></tr>
+</table>
+
+Specifies the layout mode to use for SRV3 segments.
+
+Can be either of:
+- `inline-block`: Corresponds to what YouTube's web player does. Wraps segment runs sharing a single pen in an `inline-block`. Background is applied to the `inline-block` instead of individual spans.
+- `inline`: An alternative layout mode that does not wrap segment runs in `inline-block`s, putting each one in an `inline` instead. `inline-sizing` is set to `stretch` to better match `inline-block` behavior.
+  
+  This mode avoids breaking up text shaping across segment style changes which stops segments from jumping around in karaoke subtitles. However there are cases where it "breaks" due to sizing differences or subtitles (accidentally) relying on very specific `inline-block` interactions.
+
+### srv3-default-font-size
+
+<table>
+  <tr><td><i>Default</td> <td>100</td></tr>
+  <tr><td><i>Grammar</td> <td>&lt;integer [0,2^16-1]&gt;</td></tr>
+</table>
+
+Overrides the default font size (`sz` attribute) of SRV3 pens.
+
+### srv3-default-font-style
+
+<table>
+  <!-- it's actually zero as of 2026-03-08 but that's effectively 4 -->
+  <tr><td><i>Default</td> <td>4</td></tr>
+  <tr><td><i>Grammar</td> <td>&lt;integer [1,7]&gt;</td></tr>
+</table>
+
+Overrides the default font style (`fs` attribute) of SRV3 pens.
+
+### srv3-default-fg-color
+
+<table>
+  <tr><td><i>Default</td> <td><code>#FFFFFFFF</code></td></tr>
+  <tr><td><i>Grammar</td> <td>&lt;hex-color&gt;</td></tr>
+</table>
+
+
+Overrides the default foreground color (`fc` and `fo` attributes) of SRV3 pens.  
+
+### srv3-default-bg-color
+
+<table>
+  <tr><td><i>Default</td> <td><code>#080808BF</code></td></tr>
+  <tr><td><i>Grammar</td> <td>&lt;hex-color&gt;</td></tr>
+</table>
+
+Overrides the default background color (`bc` and `bo` attributes) of SRV3 pens.  
+
+### srv3-default-edge-type
+
+<table>
+  <tr><td><i>Default</td> <td>none</td></tr>
+  <tr><td><i>Grammar</td> <td>none | hard-shadow | bevel | glow | soft-shadow</td></tr>
+</table>
+
+Overrides the default edge type (`et` attribute) of SRV3 pens.
+
+Must be one of:
+- `none`: No edge decorations.
+- `hard-shadow`: Primary color shadow.
+- `soft-shadow`: Primary color shadow with soft edges.
+- `bevel`: One primary color shadow offset to the top left and one secondary color shadow offset to the bottom right
+- `glow`: Soft primary color outline.
+
+If the edge color is defined then the primary color and secondary color are equal to the edge color.  
+Otherwise the primary color is `#222222` with alpha copied from the foreground color and the secondary color is `#CCCCCC` with alpha copied from the foreground color.
+
+### srv3-default-edge-color
+
+<table>
+  <tr><td><i>Default</td> <td>none</td></tr>
+  <tr><td><i>Grammar</td> <td>&lt;hex-color [without alpha]&gt; | none</td></tr>
+</table>
+
+Overrides the default edge color (`ec` attribute) of SRV3 pens.  
+
+If `none`, the edge color is not defined and edge decorations will use the fallback color calculations described in `srv3-edge-type` above.
+
+## Testing/debugging options
+
+Options meant to be used while working on subrandr or diagnosing issues.
+
+> [!WARNING]
+> These are unstable and their shape or existence should not be relied upon.
+
+### debug-dpi-override
+
+<table>
+  <tr><td><i>Default</td> <td>none</td></tr>
+  <tr><td><i>Grammar</td> <td>&lt;integer&gt; | none</td></tr>
+</table>
+
+If not `none`, overrides the DPI used by the renderer, ignoring the value provided via the C API.
+
+### debug-draw-version-overlay
+
+<table>
+  <tr><td><i>Default</td> <td>no</td></tr>
+  <tr><td><i>Grammar</td> <td>yes | no</td></tr>
+</table>
+
+If enabled, an overlay with version and rasterizer information will be drawn in the top-left corner.
+
+### debug-draw-perf-overlay
+
+<table>
+  <tr><td><i>Default</td> <td>no</td></tr>
+  <tr><td><i>Grammar</td> <td>yes | no</td></tr>
+</table>
+
+If enabled, an overlay with frame times and an accompanying graph will be drawn in the top-right corner.

--- a/include/config.h
+++ b/include/config.h
@@ -1,0 +1,28 @@
+#ifndef SUBRANDR_CONFIG_H
+#define SUBRANDR_CONFIG_H
+
+#include "subrandr.h"
+
+#ifdef __cplusplus
+#include <cstddef>
+#include <cstdint>
+
+extern "C" {
+#else
+#include <stddef.h>
+#include <stdint.h>
+#endif
+
+sbr_config *sbr_config_new(sbr_library *);
+
+#define SBR_ERR_OPTION_NOT_FOUND (-(int)10)
+
+int sbr_config_set_str(sbr_config *, const char *name, const char *value);
+
+void sbr_config_destroy(sbr_config *);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SUBRANDR_CONFIG_H

--- a/include/subrandr.h
+++ b/include/subrandr.h
@@ -21,6 +21,7 @@ typedef uint32_t sbr_bgra8;
 
 typedef struct sbr_library sbr_library;
 typedef struct sbr_subtitles sbr_subtitles;
+typedef struct sbr_config sbr_config;
 typedef struct sbr_renderer sbr_renderer;
 typedef struct sbr_subtitle_context {
   uint32_t dpi;
@@ -73,6 +74,7 @@ sbr_subtitles *sbr_load_text(sbr_library *, char const *content,
 void sbr_subtitles_destroy(sbr_subtitles *);
 
 sbr_renderer *sbr_renderer_create(sbr_library *);
+void sbr_renderer_set_config(sbr_renderer *, sbr_config *);
 void sbr_renderer_set_subtitles(sbr_renderer *, sbr_subtitles *);
 bool sbr_renderer_did_change(sbr_renderer *, sbr_subtitle_context const *,
                              uint32_t t);

--- a/sbr-overlay/src/main.rs
+++ b/sbr-overlay/src/main.rs
@@ -10,7 +10,7 @@ use clap::{CommandFactory, FromArgMatches};
 use log::{error, info, LogContext};
 #[cfg(feature = "wgpu")]
 use pollster::FutureExt as _;
-use subrandr::{DebugFlags, Renderer, SubtitleContext, Subtitles};
+use subrandr::{Renderer, SubtitleContext, Subtitles};
 use winit::{
     event::StartCause,
     event_loop::{self, ControlFlow, EventLoop},
@@ -136,6 +136,7 @@ struct App {
 
     start: std::time::Instant,
     subs: Option<Subtitles>,
+    config: subrandr::Config,
     renderer: Renderer,
     frame_valid_inside: Range<u32>,
 
@@ -503,6 +504,7 @@ impl winit::application::ApplicationHandler for App {
                                         .render(
                                             log,
                                             &ctx,
+                                            &self.config,
                                             t,
                                             unsafe {
                                                 std::mem::transmute::<&mut [u32], &mut [_]>(
@@ -543,7 +545,14 @@ impl winit::application::ApplicationHandler for App {
 
                                     let mut frame_rasterizer = wgpu.rasterizer.begin_frame();
                                     self.renderer
-                                        .render_to(log, &mut frame_rasterizer, &mut target, &ctx, t)
+                                        .render_to(
+                                            log,
+                                            &mut frame_rasterizer,
+                                            &mut target,
+                                            &ctx,
+                                            &self.config,
+                                            t,
+                                        )
                                         .unwrap();
                                     frame_rasterizer.end_frame();
                                     self.renderer.end_raster(log);
@@ -751,6 +760,7 @@ fn main() {
         (OverlayMode::Window(window), true) => Some(window),
     };
 
+    let log = &root_logger.new_ctx();
     event_loop
         .run_app(&mut App {
             start: std::time::Instant::now(),
@@ -771,7 +781,8 @@ fn main() {
 
             args,
             subs,
-            renderer: Renderer::new(&root_logger.new_ctx(), DebugFlags::from_env()).unwrap(),
+            config: subrandr::Config::from_env(log),
+            renderer: Renderer::new(log).unwrap(),
             frame_valid_inside: 0..0,
             state: None,
 

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -52,6 +52,7 @@ enum ErrorKind {
     Other = -1,
     InvalidArgument = -2,
 
+    OptionNotFound = -10,
     UnrecognizedFormat = -11,
 }
 
@@ -84,9 +85,13 @@ impl CError {
     }
 
     pub fn from_error(error: impl std::error::Error + Sync + 'static) -> Self {
+        Self::from_dyn_error(Box::new(error))
+    }
+
+    pub fn from_dyn_error(error: Box<dyn std::error::Error + Sync + 'static>) -> Self {
         Self {
             kind: ErrorKind::Other,
-            context: Some(Box::new(error)),
+            context: Some(error),
             message: None,
         }
     }
@@ -220,6 +225,7 @@ macro_rules! ctrywrap {
     };
 }
 
+mod config;
 mod library;
 mod renderer;
 #[cfg(target_arch = "wasm32")]

--- a/src/capi/config.rs
+++ b/src/capi/config.rs
@@ -1,0 +1,43 @@
+use std::ffi::{c_char, c_int, CStr};
+
+use crate::{
+    capi::library::CLibrary,
+    config::{Config, SetStrError},
+};
+
+pub(super) struct CConfig {
+    cfg: Config,
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn sbr_config_new(lib: &CLibrary) -> *mut CConfig {
+    let cfg = lib.get_or_init_config(&lib.root_logger.new_ctx()).clone();
+    Box::into_raw(Box::new(CConfig { cfg }))
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn sbr_config_set_str(
+    cfg: *mut CConfig,
+    name: *const c_char,
+    value: *const c_char,
+) -> c_int {
+    let Ok(name) = unsafe { CStr::from_ptr(name) }.to_str() else {
+        cthrow!(OptionNotFound, "option does not exist");
+        // non-UTF-8 options can't exist
+    };
+    let Ok(value) = unsafe { CStr::from_ptr(value) }.to_str() else {
+        cthrow!(Other, "value is not valid UTF-8");
+        // non-UTF-8 values can't be valid
+    };
+
+    match unsafe { (*cfg).cfg.set_str(name, value) } {
+        Ok(()) => 0,
+        Err(SetStrError::NotFound) => cthrow!(OptionNotFound, "option does not exist"),
+        Err(SetStrError::InvalidValue(err)) => cthrow!(super::CError::from_dyn_error(err)),
+    }
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn sbr_config_destroy(cfg: *mut CConfig) {
+    _ = unsafe { Box::from_raw(cfg) };
+}

--- a/src/capi/library.rs
+++ b/src/capi/library.rs
@@ -1,11 +1,22 @@
-use std::{cell::Cell, ffi::c_void};
+use std::{
+    cell::{Cell, OnceCell},
+    ffi::c_void,
+};
 
-use crate::DebugFlags;
+use log::LogContext;
+
+use crate::config::Config;
 
 pub struct CLibrary {
     pub(super) root_logger: log::RootLogger,
     pub(super) did_log_version: Cell<bool>,
-    pub(super) debug_flags: DebugFlags,
+    pub(super) env_config: OnceCell<Config>,
+}
+
+impl CLibrary {
+    pub(super) fn get_or_init_config(&self, log: &LogContext) -> &Config {
+        self.env_config.get_or_init(|| Config::from_env(log))
+    }
 }
 
 #[unsafe(no_mangle)]
@@ -13,7 +24,7 @@ unsafe extern "C" fn sbr_library_init() -> *mut CLibrary {
     Box::into_raw(Box::new(CLibrary {
         root_logger: log::RootLogger::new(),
         did_log_version: Cell::new(false),
-        debug_flags: DebugFlags::from_env(),
+        env_config: OnceCell::new(),
     }))
 }
 

--- a/src/capi/renderer.rs
+++ b/src/capi/renderer.rs
@@ -1,22 +1,33 @@
 use std::ffi::c_int;
 
-use log::info;
+use log::{info, LogContext};
 use rasterize::{
     color::{Premultiplied, BGRA8},
     sw::OutputPiece,
 };
 
-use crate::{capi::library::CLibrary, Renderer, SubtitleContext, Subtitles};
+use crate::{capi::library::CLibrary, Config, Renderer, SubtitleContext, Subtitles};
 
 mod instanced;
 
 pub struct CRenderer<'lib> {
     lib: &'lib CLibrary,
+    config: *const Config,
     pub(super) inner: Renderer,
     rasterizer: rasterize::sw::Rasterizer,
     output_pieces: Vec<OutputPiece>,
     output_images: Vec<instanced::COutputImage<'static>>,
     output_instances: Vec<instanced::COutputInstance<'static>>,
+}
+
+impl CRenderer<'_> {
+    unsafe fn get_or_init_config<'a>(renderer: *mut CRenderer<'a>, log: &LogContext) -> &'a Config {
+        if !(*renderer).config.is_null() {
+            &*(*renderer).config
+        } else {
+            (*renderer).lib.get_or_init_config(log)
+        }
+    }
 }
 
 #[unsafe(no_mangle)]
@@ -36,10 +47,8 @@ unsafe extern "C" fn sbr_renderer_create(lib: &CLibrary) -> *mut CRenderer<'_> {
 
     Box::into_raw(Box::new(CRenderer {
         lib,
-        inner: ctry!(Renderer::new(
-            &lib.root_logger.new_ctx(),
-            lib.debug_flags.clone()
-        )),
+        config: std::ptr::null_mut(),
+        inner: ctry!(Renderer::new(&lib.root_logger.new_ctx())),
         rasterizer: rasterize::sw::Rasterizer::new(),
         output_pieces: Vec::new(),
         output_images: Vec::new(),
@@ -53,6 +62,14 @@ unsafe extern "C" fn sbr_renderer_set_subtitles(
     subtitles: *const Subtitles,
 ) {
     (*renderer).inner.set_subtitles(subtitles.as_ref());
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn sbr_renderer_set_config(
+    renderer: *mut CRenderer,
+    config: *const crate::Config,
+) {
+    (*renderer).config = config;
 }
 
 #[unsafe(no_mangle)]
@@ -76,9 +93,10 @@ unsafe extern "C" fn sbr_renderer_render(
 ) -> c_int {
     let buffer = std::slice::from_raw_parts_mut(buffer, stride as usize * height as usize);
     let log = &(*renderer).lib.root_logger.new_ctx();
+    let cfg = CRenderer::get_or_init_config(renderer, log);
     ctry!((*renderer)
         .inner
-        .render(log, &*ctx, t, buffer, width, height, stride));
+        .render(log, &*ctx, cfg, t, buffer, width, height, stride));
     0
 }
 

--- a/src/capi/renderer/instanced.rs
+++ b/src/capi/renderer/instanced.rs
@@ -58,10 +58,11 @@ unsafe extern "C" fn sbr_renderer_render_instanced(
     if !clip_rect.is_empty() {
         let renderer = &mut (*renderer);
         let log = &renderer.lib.root_logger.new_ctx();
+        let cfg = CRenderer::get_or_init_config(renderer, log);
 
         ctry!(renderer
             .inner
-            .render_to_scene(log, &*ctx, t, &renderer.rasterizer));
+            .render_to_scene(log, &*ctx, cfg, t, &renderer.rasterizer));
 
         ctry!(renderer
             .rasterizer

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,113 @@
+use log::{debug, warn, LogContext};
+use thiserror::Error;
+
+pub(crate) trait OptionFromStr: Sized {
+    fn from_str(value: &str) -> Result<Self, util::AnyError>;
+}
+
+impl OptionFromStr for bool {
+    fn from_str(value: &str) -> Result<Self, util::AnyError> {
+        Ok(match value {
+            "yes" => true,
+            "no" => false,
+            _ => return Err("must be either \"yes\" or \"no\"".into()),
+        })
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum SetStrError {
+    #[error("option not found")]
+    NotFound,
+    #[error(transparent)]
+    InvalidValue(#[from] util::AnyError),
+}
+
+macro_rules! define_option_group {
+    ($vis: vis struct $name: ident {
+        $(
+            #[option(name = $option_name: literal $(, parse_with = $parse_fun: expr)?)]
+            $field_vis: vis $field_name: ident: $field_ty: ty = $default: expr,
+        )*
+    }) => {
+        #[derive(Debug, Clone)]
+        $vis struct $name {
+            $($field_vis $field_name: $field_ty,)*
+        }
+
+        impl $name {
+            $vis const DEFAULT: Self = Self {
+                $($field_name: $default,)*
+            };
+
+            $vis fn set_str(&mut self, name: &str, value: &str) -> Result<(), crate::config::SetStrError> {
+                match name {
+                    $($option_name =>
+                        self.$field_name = crate::config::define_option_group!(@parse value $(,$parse_fun)?),)*
+                    _ => return Err(crate::config::SetStrError::NotFound)
+                }
+
+                Ok(())
+            }
+        }
+    };
+    (@parse $value: ident) => { crate::config::OptionFromStr::from_str($value)? };
+    (@parse $value: ident, $parse_fun: expr) => { $parse_fun($value)? };
+}
+
+pub(crate) use define_option_group;
+
+macro_rules! define_config_struct {
+    (pub struct Config {$(
+        #[option(name = $group_name: literal, substruct)]
+        pub $name: ident: $substruct: ty
+    ),*}) => {
+        #[derive(Debug, Clone)]
+        pub struct Config {
+            $(pub(crate) $name: $substruct,)*
+        }
+
+        impl Config {
+            pub const DEFAULT: Self = Self {
+                $($name: <$substruct>::DEFAULT,)*
+            };
+
+            pub fn set_str(&mut self, name: &str, value: &str) -> Result<(), crate::config::SetStrError> {
+                $(
+                if let Some(rest) = name.strip_prefix(concat!($group_name, "-")) {
+                    return self.$name.set_str(rest, value);
+                }
+                )*
+
+                Err(crate::config::SetStrError::NotFound)
+            }
+        }
+    };
+}
+
+define_config_struct! {
+    pub struct Config {
+        #[option(name = "srv3", substruct)]
+        pub srv3: crate::srv3::Options,
+        #[option(name = "debug", substruct)]
+        pub debug: crate::renderer::DebugOptions
+    }
+}
+
+impl Config {
+    pub fn from_env(log: &LogContext) -> Self {
+        let mut result = Config::DEFAULT;
+
+        if let Ok(s) = std::env::var("SBR_CONFIG") {
+            for token in s.split(",") {
+                let (key, value) = token.split_once("=").unwrap_or((token, "yes"));
+                if let Err(err) = result.set_str(key, value) {
+                    warn!(log, "error setting `{key}={value}` from environment: {err}");
+                }
+                debug!(log, "set `{key}={value}` from environment")
+            }
+        }
+
+        result
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,37 @@ impl OptionFromStr for bool {
     }
 }
 
+macro_rules! impl_from_str_parser {
+    ($($type: ty),*) => {
+        $(impl OptionFromStr for $type {
+            fn from_str(s: &str) -> Result<Self, util::AnyError> {
+                <$type as std::str::FromStr>::from_str(s).map_err(Into::into)
+            }
+        })*
+    };
+}
+
+impl_from_str_parser!(u8, u16, u32, u64, u128);
+impl_from_str_parser!(i8, i16, i32, i64, i128);
+
+impl OptionFromStr for BGRA8 {
+    fn from_str(s: &str) -> Result<Self, util::AnyError> {
+        const ERROR: &str = "must be a color in #RRGGBB(AA) form";
+
+        let hex = s.strip_prefix("#").ok_or(ERROR)?;
+        if hex.len() != 6 && hex.len() != 8 {
+            return Err(ERROR.into());
+        }
+
+        let mut value = u32::from_str_radix(hex, 16)?;
+        if hex.len() == 6 {
+            value <<= 8;
+            value |= 0xFF;
+        }
+        Ok(Self::from_rgba32(value))
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum SetStrError {
     #[error("option not found")]
@@ -56,6 +87,7 @@ macro_rules! define_option_group {
 }
 
 pub(crate) use define_option_group;
+use rasterize::color::BGRA8;
 
 macro_rules! define_config_struct {
     (pub struct Config {$(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,6 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::missing_transmute_annotations)]
 
-use std::fmt::Debug;
-
 pub use rasterize;
 pub use util::math::I26Dot6;
 
@@ -11,46 +9,13 @@ pub mod srv3;
 pub mod vtt;
 
 mod capi;
+pub mod config;
 mod display;
 mod html;
 mod layout;
 mod style;
 mod text;
-
-#[derive(Default, Debug, Clone)]
-pub struct DebugFlags {
-    draw_version_string: bool,
-    draw_perf_info: bool,
-    dpi_override: Option<u32>,
-    srv3_use_inlines: bool,
-}
-
-impl DebugFlags {
-    pub fn from_env() -> Self {
-        let mut result = Self::default();
-
-        if let Ok(s) = std::env::var("SBR_DEBUG") {
-            for token in s.split(",") {
-                match token {
-                    "draw_version" => result.draw_version_string = true,
-                    "draw_perf" => result.draw_perf_info = true,
-                    "srv3_use_inlines" => result.srv3_use_inlines = true,
-                    #[allow(clippy::single_match)]
-                    _ => match token.split_once("=") {
-                        Some(("override_dpi", value_str)) => {
-                            if let Ok(value) = value_str.parse::<u32>() {
-                                result.dpi_override = Some(value)
-                            }
-                        }
-                        _ => (),
-                    },
-                }
-            }
-        }
-
-        result
-    }
-}
+pub use config::Config;
 
 mod renderer;
 pub use renderer::{Renderer, SubtitleContext, Subtitles};

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -19,6 +19,7 @@ use util::{
 };
 
 use crate::{
+    config::{define_option_group, Config},
     display::DisplayPass,
     layout::{
         self,
@@ -29,8 +30,29 @@ use crate::{
     srv3,
     style::{computed::HorizontalAlignment, ComputedStyle},
     text::{self, platform_font_provider},
-    vtt, DebugFlags,
+    vtt,
 };
+
+fn parse_option_u32(value: &str) -> Result<Option<u32>, util::AnyError> {
+    match value {
+        "none" => Ok(None),
+        _ if value.bytes().any(|b| !b.is_ascii_digit()) => {
+            Err("value must be a number or \"none\"".into())
+        }
+        _ => Ok(Some(value.parse()?)),
+    }
+}
+
+define_option_group! {
+    pub struct DebugOptions {
+        #[option(name = "draw-version-overlay")]
+        pub draw_version_overlay: bool = false,
+        #[option(name = "draw-perf-overlay")]
+        pub draw_perf_overlay: bool = false,
+        #[option(name = "dpi-override", parse_with  = parse_option_u32)]
+        pub render_dpi_override: Option<u32> = None,
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(C)]
@@ -80,14 +102,11 @@ enum FormatLayouter {
 
 pub(crate) struct FrameLayoutPass<'frame> {
     pub sctx: &'frame SubtitleContext,
+    pub cfg: &'frame Config,
     pub lctx: &'frame mut LayoutContext<'frame>,
     pub t: u32,
     unchanged_range: Range<u32>,
     fragments: Vec<(Point2L, BlockContainerFragment)>,
-    // TODO: proper configuration system
-    // TODO: fully inline mode could probably keep using blocks for ruby which would clean
-    //       up a sizing hack in inline layout
-    pub srv3_use_inlines: bool,
 }
 
 impl AsLogger for FrameLayoutPass<'_> {
@@ -297,7 +316,6 @@ impl PerfStats {
 }
 
 pub struct Renderer {
-    debug_flags: DebugFlags,
     pub(crate) fonts: text::FontDb,
     pub(crate) glyph_cache: text::GlyphCache,
     perf: PerfStats,
@@ -310,12 +328,8 @@ pub struct Renderer {
 }
 
 impl Renderer {
-    pub fn new(
-        log: &LogContext,
-        debug_flags: DebugFlags,
-    ) -> Result<Self, platform_font_provider::InitError> {
+    pub fn new(log: &LogContext) -> Result<Self, platform_font_provider::InitError> {
         Ok(Self {
-            debug_flags,
             fonts: text::FontDb::new(log)?,
             glyph_cache: text::GlyphCache::new(),
             perf: PerfStats::new(),
@@ -397,6 +411,7 @@ impl Renderer {
         &mut self,
         log: &LogContext,
         ctx: &SubtitleContext,
+        cfg: &Config,
         t: u32,
         buffer: &mut [Premultiplied<BGRA8>],
         width: u32,
@@ -408,6 +423,7 @@ impl Renderer {
             &mut rasterize::sw::Rasterizer::new(),
             &mut rasterize::sw::RenderTarget::new(buffer, width, height, stride).into(),
             ctx,
+            cfg,
             t,
         )
         .inspect(|_| self.end_raster(log))
@@ -419,16 +435,17 @@ impl Renderer {
         rasterizer: &mut dyn rasterize::Rasterizer,
         target: &mut rasterize::RenderTarget,
         ctx: &SubtitleContext,
+        cfg: &Config,
         t: u32,
     ) -> Result<(), RenderError> {
-        self.render_to_scene(log, ctx, t, rasterizer)?;
+        self.render_to_scene(log, ctx, cfg, t, rasterizer)?;
         rasterizer.render_scene(target, &self.scene, &self.glyph_cache)?;
 
         Ok(())
     }
 
     fn layout_debug_overlay(
-        debug_flags: &DebugFlags,
+        cfg: &Config,
         perf: &PerfStats,
         lctx: &mut LayoutContext,
         ctx: &SubtitleContext,
@@ -443,7 +460,7 @@ impl Renderer {
             result
         };
 
-        if debug_flags.draw_version_string {
+        if cfg.debug.draw_version_overlay {
             let mut builder = InlineContentBuilder::new(base_style.clone());
             let mut root = builder.root();
 
@@ -488,7 +505,7 @@ impl Renderer {
             ));
         }
 
-        if debug_flags.draw_perf_info {
+        if cfg.debug.draw_perf_overlay {
             let mut builder = InlineContentBuilder::new({
                 let mut style = base_style.clone();
                 *style.make_text_align_mut() = HorizontalAlignment::Right;
@@ -573,6 +590,7 @@ impl Renderer {
         &mut self,
         log: &LogContext,
         ctx: &SubtitleContext,
+        cfg: &Config,
         t: u32,
         rasterizer: &dyn Rasterizer,
     ) -> Result<(), RenderError> {
@@ -584,7 +602,7 @@ impl Renderer {
         self.scene.clear();
 
         let ctx = SubtitleContext {
-            dpi: self.debug_flags.dpi_override.unwrap_or(ctx.dpi),
+            dpi: cfg.debug.render_dpi_override.unwrap_or(ctx.dpi),
             ..*ctx
         };
 
@@ -607,6 +625,7 @@ impl Renderer {
         {
             let mut pass = FrameLayoutPass {
                 sctx: &ctx,
+                cfg,
                 lctx: &mut LayoutContext {
                     log,
                     dpi: ctx.dpi,
@@ -615,7 +634,6 @@ impl Renderer {
                 t,
                 unchanged_range: 0..u32::MAX,
                 fragments: Vec::new(),
-                srv3_use_inlines: self.debug_flags.srv3_use_inlines,
             };
 
             fragments = {
@@ -631,7 +649,7 @@ impl Renderer {
             self.perf.end_layout();
 
             Self::layout_debug_overlay(
-                &self.debug_flags,
+                cfg,
                 &self.perf,
                 pass.lctx,
                 &ctx,

--- a/src/srv3/convert.rs
+++ b/src/srv3/convert.rs
@@ -262,6 +262,17 @@ fn parse_edge_color(s: &str) -> Result<Option<u32>, util::AnyError> {
     Ok(Some(u32::from_str_radix(hex, 16)?))
 }
 
+fn parse_point(s: &str) -> Result<Point, util::AnyError> {
+    s.parse()
+}
+
+fn parse_win_coordinate(s: &str) -> Result<u32, util::AnyError> {
+    s.parse()
+        .ok()
+        .filter(|&x| x <= 100)
+        .ok_or_else(|| "must be an integer in the range [0, 100]".into())
+}
+
 // `pen` attribute defaults
 pub const DEFAULT_PEN_FONT_SIZE: u16 = 100;
 pub const DEFAULT_PEN_FONT_STYLE: u32 = 0;
@@ -297,6 +308,12 @@ crate::config::define_option_group! {
         default_edge_type: EdgeType = EdgeType::None,
         #[option(name = "default-edge-color", parse_with = parse_edge_color)]
         default_edge_color: Option<u32> = None,
+        #[option(name = "default-win-align", parse_with = parse_point)]
+        default_win_align: Point = DEFAULT_WIN_POINT,
+        #[option(name = "default-win-x", parse_with = parse_win_coordinate)]
+        default_win_x: u32 = DEFAULT_WIN_X,
+        #[option(name = "default-win-y", parse_with = parse_win_coordinate)]
+        default_win_y: u32 = DEFAULT_WIN_Y,
     }
 }
 
@@ -613,8 +630,11 @@ impl Window {
         pass: &mut FrameLayoutPass,
     ) -> Result<Option<(Point2L, layout::block::BlockContainerFragment)>, layout::InlineLayoutError>
     {
-        let Alignment(text_align, vertical_align) =
-            self.pos.point().unwrap_or(DEFAULT_WIN_POINT).to_alignment();
+        let Alignment(text_align, vertical_align) = self
+            .pos
+            .point()
+            .unwrap_or(pass.cfg.srv3.default_win_align)
+            .to_alignment();
         let inner_style = {
             let mut result = ComputedStyle::DEFAULT;
             *result.make_direction_mut() = self.text_direction;
@@ -655,8 +675,10 @@ impl Window {
 
         let fragment = partial_window.layout(pass.lctx, &constraints)?;
 
-        let x_percentage = convert_coordinate(self.pos.x().unwrap_or(DEFAULT_WIN_X) as f32);
-        let y_percentage = convert_coordinate(self.pos.y().unwrap_or(DEFAULT_WIN_Y) as f32);
+        let x_percentage =
+            convert_coordinate(self.pos.x().unwrap_or(pass.cfg.srv3.default_win_x) as f32);
+        let y_percentage =
+            convert_coordinate(self.pos.y().unwrap_or(pass.cfg.srv3.default_win_y) as f32);
         let mut pos = Point2L::new(
             (x_percentage * pass.sctx.player_width().into_f32()).into(),
             (y_percentage * pass.sctx.player_height().into_f32()).into(),

--- a/src/srv3/convert.rs
+++ b/src/srv3/convert.rs
@@ -9,6 +9,7 @@ use util::{
 };
 
 use crate::{
+    config::Config,
     layout::{
         self,
         block::{BlockContainer, BlockContainerContent},
@@ -227,10 +228,75 @@ impl crate::config::OptionFromStr for LayoutMode {
     }
 }
 
+fn parse_font_style(s: &str) -> Result<u32, util::AnyError> {
+    let value = s.parse::<u32>()?;
+    if value == 0 || value as usize > SRV3_FONTS.len() {
+        return Err(format!("must be an integer in the range [1, {}]", SRV3_FONTS.len()).into());
+    }
+    Ok(value)
+}
+
+fn parse_edge_type(s: &str) -> Result<EdgeType, util::AnyError> {
+    Ok(match s {
+        "none" => EdgeType::None,
+        "hard-shadow" => EdgeType::HardShadow,
+        "bevel" => EdgeType::Bevel,
+        "glow" => EdgeType::Glow,
+        "soft-shadow" => EdgeType::SoftShadow,
+        _ => return Err("not a valid edge type".into()),
+    })
+}
+
+fn parse_edge_color(s: &str) -> Result<Option<u32>, util::AnyError> {
+    const ERROR: &str = "must be a color in #RRGGBB form or \"none\"";
+
+    if s == "none" {
+        return Ok(None);
+    }
+
+    let hex = s.strip_prefix("#").ok_or(ERROR)?;
+    if hex.len() != 6 {
+        return Err(ERROR.into());
+    }
+
+    Ok(Some(u32::from_str_radix(hex, 16)?))
+}
+
+// `pen` attribute defaults
+pub const DEFAULT_PEN_FONT_SIZE: u16 = 100;
+pub const DEFAULT_PEN_FONT_STYLE: u32 = 0;
+pub const DEFAULT_PEN_BOLD: bool = false;
+pub const DEFAULT_PEN_ITALIC: bool = false;
+pub const DEFAULT_PEN_UNDERLINE: bool = false;
+pub const DEFAULT_PEN_EDGE_TYPE: EdgeType = EdgeType::None;
+pub const DEFAULT_PEN_RUBY_PART: RubyPart = RubyPart::None;
+pub const DEFAULT_PEN_FOREGROUND_COLOR: BGRA8 = BGRA8::from_rgba32(0xFFFFFFFF);
+// The default opacity is 0.75, round(0.75 * 255) = 0xBF
+pub const DEFAULT_PEN_BACKGROUND_COLOR: BGRA8 = BGRA8::from_rgba32(0x080808BF);
+
+// `wp` attribute defaults
+pub const DEFAULT_WIN_POINT: Point = Point::BottomCenter;
+pub const DEFAULT_WIN_X: u32 = 50;
+pub const DEFAULT_WIN_Y: u32 = 100;
+// `ws` attribute defaults
+pub const DEFAULT_WIN_MODE_HINT: ModeHint = ModeHint::Default;
+
 crate::config::define_option_group! {
     pub(crate) struct Options {
         #[option(name = "layout-mode")]
         layout_mode: LayoutMode = LayoutMode::InlineBlock,
+        #[option(name = "default-font-size")]
+        default_font_size: u16 = DEFAULT_PEN_FONT_SIZE,
+        #[option(name = "default-font-style", parse_with = parse_font_style)]
+        default_font_style: u32 = DEFAULT_PEN_FONT_STYLE,
+        #[option(name = "default-fg-color")]
+        default_foreground_color: BGRA8 = DEFAULT_PEN_FOREGROUND_COLOR,
+        #[option(name = "default-bg-color")]
+        default_background_color: BGRA8 = DEFAULT_PEN_BACKGROUND_COLOR,
+        #[option(name = "default-edge-type", parse_with = parse_edge_type)]
+        default_edge_type: EdgeType = EdgeType::None,
+        #[option(name = "default-edge-color", parse_with = parse_edge_color)]
+        default_edge_color: Option<u32> = None,
     }
 }
 
@@ -250,48 +316,28 @@ struct ComputedPen {
     background_color: rasterize::color::BGRA8,
 }
 
-// `pen` attribute defaults
-pub const DEFAULT_PEN_FONT_SIZE: u16 = 100;
-pub const DEFAULT_PEN_FONT_STYLE: u32 = 0;
-pub const DEFAULT_PEN_BOLD: bool = false;
-pub const DEFAULT_PEN_ITALIC: bool = false;
-pub const DEFAULT_PEN_UNDERLINE: bool = false;
-pub const DEFAULT_PEN_EDGE_TYPE: EdgeType = EdgeType::None;
-pub const DEFAULT_PEN_RUBY_PART: RubyPart = RubyPart::None;
-pub const DEFAULT_PEN_FOREGROUND_COLOR: u32 = 0xFFFFFFFF;
-// The default opacity is 0.75, round(0.75 * 255) = 0xBF
-pub const DEFAULT_PEN_BACKGROUND_COLOR: u32 = 0x080808BF;
-
-// `wp` attribute defaults
-pub const DEFAULT_WIN_POINT: Point = Point::BottomCenter;
-pub const DEFAULT_WIN_X: u32 = 50;
-pub const DEFAULT_WIN_Y: u32 = 100;
-// `ws` attribute defaults
-pub const DEFAULT_WIN_MODE_HINT: ModeHint = ModeHint::Default;
-
 impl Segment {
-    fn compute_pen(&self, pen: &Pen) -> ComputedPen {
+    fn compute_pen(&self, pen: &Pen, cfg: &Config) -> ComputedPen {
         fn compute_color(default: u32, color: Option<u32>, opacity: Option<u8>) -> BGRA8 {
             BGRA8::from_argb32(
                 color.unwrap_or(default >> 8) | (u32::from(opacity.unwrap_or(default as u8)) << 24),
             )
         }
-
         ComputedPen {
-            font_size: pen.font_size().unwrap_or(DEFAULT_PEN_FONT_SIZE),
-            font_style: pen.font_style().unwrap_or(DEFAULT_PEN_FONT_STYLE),
+            font_size: pen.font_size().unwrap_or(cfg.srv3.default_font_size),
+            font_style: pen.font_style().unwrap_or(cfg.srv3.default_font_style),
             bold: pen.bold().unwrap_or(DEFAULT_PEN_BOLD),
             italic: pen.italic().unwrap_or(DEFAULT_PEN_ITALIC),
             underline: pen.underline().unwrap_or(DEFAULT_PEN_UNDERLINE),
-            edge_type: pen.edge_type().unwrap_or(DEFAULT_PEN_EDGE_TYPE),
-            edge_color: pen.edge_color(),
+            edge_type: pen.edge_type().unwrap_or(cfg.srv3.default_edge_type),
+            edge_color: pen.edge_color().or(cfg.srv3.default_edge_color),
             foreground_color: compute_color(
-                DEFAULT_PEN_FOREGROUND_COLOR,
+                cfg.srv3.default_foreground_color.to_rgba32(),
                 pen.foreground_color(),
                 pen.foreground_opacity(),
             ),
             background_color: compute_color(
-                DEFAULT_PEN_BACKGROUND_COLOR,
+                cfg.srv3.default_background_color.to_rgba32(),
                 pen.background_color(),
                 pen.background_opacity(),
             ),
@@ -397,7 +443,7 @@ impl VisualLine {
             *result.make_inline_sizing_mut() = InlineSizing::Stretch;
         }
 
-        let pen = segment.compute_pen(&segment.pen);
+        let pen = segment.compute_pen(&segment.pen, pass.cfg);
         *result.make_font_size_mut() =
             I26Dot6::from(font_size_to_pixels(pen.font_size) * font_scale_from_ctx(pass.sctx));
         *result.make_font_family_mut() = font_style_to_families(pen.font_style).clone();

--- a/src/srv3/convert.rs
+++ b/src/srv3/convert.rs
@@ -16,7 +16,10 @@ use crate::{
         FixedL, InlineLayoutError, LayoutConstraints, Point2L, Vec2L,
     },
     renderer::FrameLayoutPass,
-    srv3::{BodyParser, Event, ModeHint, RubyPosition},
+    srv3::{
+        BodyParser, EdgeType, Event, ModeHint, Pen, Point, RubyPart, RubyPosition, WindowPos,
+        WindowStyle,
+    },
     style::{
         computed::{
             Alignment, Direction, FontSlant, HorizontalAlignment, InlineSizing, Length, TextShadow,
@@ -27,8 +30,6 @@ use crate::{
     text::OpenTypeTag,
     SubtitleContext,
 };
-
-use super::{EdgeType, Pen, RubyPart};
 
 macro_rules! static_rc_of_static_strings {
     [$($values: literal),* $(,)?] => {
@@ -179,14 +180,12 @@ pub struct Subtitles {
 
 #[derive(Debug)]
 struct Window {
-    x: f32,
-    y: f32,
+    pos: WindowPos,
+    text_direction: Direction,
     // TODO: What the heck does this do
     //       How does a timestamp on a window work?
     //       Currently this is just ignored until I figure out what to do with it.
     range: Range<u32>,
-    segment_style: ComputedStyle,
-    vertical_align: VerticalAlignment,
     lines: Vec<VisualLine>,
     mode_hint: ModeHint,
 }
@@ -200,7 +199,6 @@ struct VisualLine {
 #[derive(Debug, Clone)]
 struct Segment {
     pen: Pen,
-    base_style: ComputedStyle,
     time_offset: u32,
     text: std::rc::Rc<str>,
 }
@@ -236,19 +234,87 @@ crate::config::define_option_group! {
     }
 }
 
+#[derive(Debug, Clone)]
+struct ComputedPen {
+    font_size: u16,
+    font_style: u32,
+
+    bold: bool,
+    italic: bool,
+    underline: bool,
+
+    edge_type: EdgeType,
+    edge_color: Option<u32>,
+
+    foreground_color: rasterize::color::BGRA8,
+    background_color: rasterize::color::BGRA8,
+}
+
+// `pen` attribute defaults
+pub const DEFAULT_PEN_FONT_SIZE: u16 = 100;
+pub const DEFAULT_PEN_FONT_STYLE: u32 = 0;
+pub const DEFAULT_PEN_BOLD: bool = false;
+pub const DEFAULT_PEN_ITALIC: bool = false;
+pub const DEFAULT_PEN_UNDERLINE: bool = false;
+pub const DEFAULT_PEN_EDGE_TYPE: EdgeType = EdgeType::None;
+pub const DEFAULT_PEN_RUBY_PART: RubyPart = RubyPart::None;
+pub const DEFAULT_PEN_FOREGROUND_COLOR: u32 = 0xFFFFFFFF;
+// The default opacity is 0.75, round(0.75 * 255) = 0xBF
+pub const DEFAULT_PEN_BACKGROUND_COLOR: u32 = 0x080808BF;
+
+// `wp` attribute defaults
+pub const DEFAULT_WIN_POINT: Point = Point::BottomCenter;
+pub const DEFAULT_WIN_X: u32 = 50;
+pub const DEFAULT_WIN_Y: u32 = 100;
+// `ws` attribute defaults
+pub const DEFAULT_WIN_MODE_HINT: ModeHint = ModeHint::Default;
+
 impl Segment {
-    fn compute_shadows(&self, ctx: &SubtitleContext, out: &mut Vec<TextShadow>) {
+    fn compute_pen(&self, pen: &Pen) -> ComputedPen {
+        fn compute_color(default: u32, color: Option<u32>, opacity: Option<u8>) -> BGRA8 {
+            BGRA8::from_argb32(
+                color.unwrap_or(default >> 8) | (u32::from(opacity.unwrap_or(default as u8)) << 24),
+            )
+        }
+
+        ComputedPen {
+            font_size: pen.font_size().unwrap_or(DEFAULT_PEN_FONT_SIZE),
+            font_style: pen.font_style().unwrap_or(DEFAULT_PEN_FONT_STYLE),
+            bold: pen.bold().unwrap_or(DEFAULT_PEN_BOLD),
+            italic: pen.italic().unwrap_or(DEFAULT_PEN_ITALIC),
+            underline: pen.underline().unwrap_or(DEFAULT_PEN_UNDERLINE),
+            edge_type: pen.edge_type().unwrap_or(DEFAULT_PEN_EDGE_TYPE),
+            edge_color: pen.edge_color(),
+            foreground_color: compute_color(
+                DEFAULT_PEN_FOREGROUND_COLOR,
+                pen.foreground_color(),
+                pen.foreground_opacity(),
+            ),
+            background_color: compute_color(
+                DEFAULT_PEN_BACKGROUND_COLOR,
+                pen.background_color(),
+                pen.background_opacity(),
+            ),
+        }
+    }
+
+    fn compute_shadows(
+        &self,
+        ctx: &SubtitleContext,
+        style: &ComputedPen,
+        out: &mut Vec<TextShadow>,
+    ) {
         let scale = FixedL::from_f32(font_scale_from_ctx(ctx) / 32.0);
         let l1 = Length::from_pixels((scale).max(FixedL::ONE));
         let l2 = Length::from_pixels((scale * 2).max(FixedL::ONE));
         let l3 = Length::from_pixels((scale * 3).max(FixedL::ONE));
         let l5 = Length::from_pixels((scale * 5).max(FixedL::ONE));
-        let primary_color = BGRA8::from_argb32(self.pen.edge_color.map_or_else(
-            || 0x222222 | (self.pen.foreground_color << 24),
+        let primary_color = BGRA8::from_argb32(style.edge_color.map_or_else(
+            || 0x222222 | (u32::from(style.foreground_color.a) << 24),
             |c| c | 0xFF000000,
         ));
 
-        match self.pen.edge_type {
+        match style.edge_type {
             EdgeType::None => (),
             EdgeType::HardShadow => {
                 let step = Length::HALF * (ctx.dpi < 144) as i32 + Length::HALF;
@@ -267,8 +333,8 @@ impl Segment {
                 // distinct colors for the positive-offset and negative-offset shadow.
                 // The "inner" shadow will end up with a very light gray but the "outer" one
                 // will be the usual black.
-                let secondary_color = if self.pen.edge_color.is_none() {
-                    BGRA8::from_argb32(0xCCCCCC | (self.pen.foreground_color << 24))
+                let secondary_color = if style.edge_color.is_none() {
+                    BGRA8::from_argb32(0xCCCCCC | (u32::from(style.foreground_color.a) << 24))
                 } else {
                     primary_color
                 };
@@ -314,8 +380,9 @@ impl VisualLine {
         pass: &mut FrameLayoutPass,
         segment: &Segment,
         mh: ModeHint,
+        base: &ComputedStyle,
     ) -> Option<ComputedStyle> {
-        let mut result = segment.base_style.clone();
+        let mut result = base.clone();
         pass.add_animation_point(self.range.start + segment.time_offset);
         if segment.time_offset > pass.t - self.range.start {
             match mh {
@@ -330,12 +397,30 @@ impl VisualLine {
             *result.make_inline_sizing_mut() = InlineSizing::Stretch;
         }
 
-        *result.make_font_size_mut() = I26Dot6::from(
-            font_size_to_pixels(segment.pen.font_size) * font_scale_from_ctx(pass.sctx),
-        );
+        let pen = segment.compute_pen(&segment.pen);
+        *result.make_font_size_mut() =
+            I26Dot6::from(font_size_to_pixels(pen.font_size) * font_scale_from_ctx(pass.sctx));
+        *result.make_font_family_mut() = font_style_to_families(pen.font_style).clone();
+
+        if pen.bold {
+            *result.make_font_weight_mut() = I16Dot16::new(700);
+        }
+
+        if pen.italic {
+            *result.make_font_slant_mut() = FontSlant::Italic;
+        }
+
+        if pen.underline {
+            let decorations = result.make_text_decoration_mut();
+            decorations.underline = true;
+            decorations.underline_color = pen.foreground_color;
+        }
+
+        *result.make_color_mut() = pen.foreground_color;
+        *result.make_background_color_mut() = pen.background_color;
 
         let mut shadows = vec![];
-        segment.compute_shadows(pass.sctx, &mut shadows);
+        segment.compute_shadows(pass.sctx, &pen, &mut shadows);
 
         if !shadows.is_empty() {
             *result.make_text_shadows_mut() = shadows.into();
@@ -350,12 +435,14 @@ impl VisualLine {
         root_inline_style: ComputedStyle,
         mh: ModeHint,
     ) -> InlineContent {
-        let mut builder = InlineContentBuilder::new(root_inline_style);
+        let mut builder = InlineContentBuilder::new(root_inline_style.clone());
         let mut root = builder.root();
         let mut it = self.segments.iter();
-        let mut take_next = move |pass: &mut FrameLayoutPass| loop {
+        let mut take_next = |pass: &mut FrameLayoutPass| loop {
             let segment = it.next()?;
-            if let Some(style) = self.compute_segment_style(pass, &segment.inner, mh) {
+            if let Some(style) =
+                self.compute_segment_style(pass, &segment.inner, mh, &root_inline_style)
+            {
                 break Some((segment, style));
             }
         };
@@ -411,7 +498,7 @@ impl VisualLine {
                             .push_text(&segment.inner.text);
 
                         if let Some(annotation_style) = self
-                            .compute_segment_style(pass, annotation_segment, mh)
+                            .compute_segment_style(pass, annotation_segment, mh, &root_inline_style)
                             .map(|mut style| {
                                 // If inline-block layout is enabled then background is handled by the
                                 // containing block.
@@ -480,11 +567,15 @@ impl Window {
         pass: &mut FrameLayoutPass,
     ) -> Result<Option<(Point2L, layout::block::BlockContainerFragment)>, layout::InlineLayoutError>
     {
+        let Alignment(text_align, vertical_align) =
+            self.pos.point().unwrap_or(DEFAULT_WIN_POINT).to_alignment();
         let inner_style = {
-            let mut result = self.segment_style.clone();
-            *result.make_background_color_mut() = BGRA8::ZERO;
+            let mut result = ComputedStyle::DEFAULT;
+            *result.make_direction_mut() = self.text_direction;
+            *result.make_text_align_mut() = text_align;
             result
         };
+
         let mut lines = Vec::new();
         for line in &self.lines {
             if pass.add_event_range(line.range.clone()) {
@@ -492,7 +583,7 @@ impl Window {
                     style: inner_style.clone(),
                     content: BlockContainerContent::Inline(line.to_inline_content(
                         pass,
-                        self.segment_style.clone(),
+                        inner_style.clone(),
                         self.mode_hint,
                     )),
                 });
@@ -518,19 +609,21 @@ impl Window {
 
         let fragment = partial_window.layout(pass.lctx, &constraints)?;
 
+        let x_percentage = convert_coordinate(self.pos.x().unwrap_or(DEFAULT_WIN_X) as f32);
+        let y_percentage = convert_coordinate(self.pos.y().unwrap_or(DEFAULT_WIN_Y) as f32);
         let mut pos = Point2L::new(
-            (self.x * pass.sctx.player_width().into_f32()).into(),
-            (self.y * pass.sctx.player_height().into_f32()).into(),
+            (x_percentage * pass.sctx.player_width().into_f32()).into(),
+            (y_percentage * pass.sctx.player_height().into_f32()).into(),
         );
 
         let fragment_size = fragment.fbox.size_for_layout();
-        match self.segment_style.text_align() {
+        match text_align {
             HorizontalAlignment::Left => (),
             HorizontalAlignment::Center => pos.x -= fragment_size.x / 2,
             HorizontalAlignment::Right => pos.x -= fragment_size.x,
         }
 
-        match self.vertical_align {
+        match vertical_align {
             VerticalAlignment::Top => (),
             VerticalAlignment::Center => pos.y -= fragment_size.y / 2,
             VerticalAlignment::Bottom => pos.y -= fragment_size.y,
@@ -540,45 +633,9 @@ impl Window {
     }
 }
 
-fn pen_to_size_independent_style(
-    pen: &Pen,
-    set_default: bool,
-    mut base: ComputedStyle,
-) -> ComputedStyle {
-    if set_default || pen.font_style != Pen::DEFAULT.font_style {
-        *base.make_font_family_mut() = font_style_to_families(pen.font_style).clone();
-    }
-
-    if pen.bold {
-        *base.make_font_weight_mut() = I16Dot16::new(700);
-    }
-
-    if pen.italic {
-        *base.make_font_slant_mut() = FontSlant::Italic;
-    }
-
-    let bgra_foreground_color = BGRA8::from_rgba32(pen.foreground_color);
-    if pen.underline {
-        let decorations = base.make_text_decoration_mut();
-        decorations.underline = true;
-        decorations.underline_color = bgra_foreground_color;
-    }
-
-    if set_default || pen.foreground_color != Pen::DEFAULT.foreground_color {
-        *base.make_color_mut() = bgra_foreground_color;
-    }
-
-    if set_default || pen.background_color != Pen::DEFAULT.background_color {
-        *base.make_background_color_mut() = BGRA8::from_rgba32(pen.background_color);
-    }
-
-    base
-}
-
-fn convert_segment(segment: &super::Segment, text: &str, base_style: &ComputedStyle) -> Segment {
+fn convert_segment(segment: &super::Segment, text: &str) -> Segment {
     Segment {
         pen: *segment.pen,
-        base_style: pen_to_size_independent_style(segment.pen, false, base_style.clone()),
         time_offset: segment.time_offset,
         text: text.into(),
     }
@@ -586,32 +643,24 @@ fn convert_segment(segment: &super::Segment, text: &str, base_style: &ComputedSt
 
 struct WindowBuilder<'a> {
     log: &'a LogContext<'a>,
-    base_style: ComputedStyle,
+    text_direction: Direction,
     logset: LogOnceSet,
 }
 
 impl WindowBuilder<'_> {
     fn create_window(
         &self,
-        x: f32,
-        y: f32,
+        pos: WindowPos,
+        style: WindowStyle,
         time: u32,
         duration: u32,
-        align: Alignment,
-        mode_hint: ModeHint,
     ) -> Window {
         Window {
-            x,
-            y,
+            pos,
+            text_direction: self.text_direction,
             range: time..time + duration,
-            segment_style: {
-                let mut style = self.base_style.clone();
-                *style.make_text_align_mut() = align.0;
-                style
-            },
-            vertical_align: align.1,
             lines: Vec::new(),
-            mode_hint,
+            mode_hint: style.mode_hint().unwrap_or(DEFAULT_WIN_MODE_HINT),
         }
     }
 
@@ -627,11 +676,11 @@ impl WindowBuilder<'_> {
         let mut it = event.segments.iter();
         'segment_loop: while let Some(segment) = it.next() {
             'ruby_failed: {
-                if segment.pen.ruby_part == RubyPart::Base && it.as_slice().len() > 3 {
+                if segment.pen.ruby_part() == Some(RubyPart::Base) && it.as_slice().len() > 3 {
                     let ruby_block = <&[_; 3]>::try_from(&it.as_slice()[..3]).unwrap();
 
-                    let [RubyPart::Parenthesis, RubyPart::Ruby(part), RubyPart::Parenthesis] =
-                        ruby_block.each_ref().map(|s| s.pen.ruby_part)
+                    let [Some(RubyPart::Parenthesis), Some(RubyPart::Ruby(part)), Some(RubyPart::Parenthesis)] =
+                        ruby_block.each_ref().map(|s| s.pen.ruby_part())
                     else {
                         break 'ruby_failed;
                     };
@@ -651,8 +700,8 @@ impl WindowBuilder<'_> {
                     _ = it.next().unwrap();
                     let next = it.next().unwrap();
                     current_line.segments.push(LineSegment {
-                        inner: convert_segment(segment, &segment.text, &window.segment_style),
-                        annotation: Some(convert_segment(next, &next.text, &window.segment_style)),
+                        inner: convert_segment(segment, &segment.text),
+                        annotation: Some(convert_segment(next, &next.text)),
                     });
                     _ = it.next().unwrap();
 
@@ -667,11 +716,7 @@ impl WindowBuilder<'_> {
                     .map_or(segment.text.len(), |i| last + i);
 
                 current_line.segments.push(LineSegment {
-                    inner: convert_segment(
-                        segment,
-                        &segment.text[last..end],
-                        &window.segment_style,
-                    ),
+                    inner: convert_segment(segment, &segment.text[last..end]),
                     annotation: None,
                 });
 
@@ -702,15 +747,12 @@ pub fn convert(
     };
     let mut window_builder = WindowBuilder {
         log,
-        base_style: {
-            let mut style =
-                pen_to_size_independent_style(&Pen::DEFAULT, true, ComputedStyle::DEFAULT);
-            if let Some(lang) = lang {
-                if LocaleDirectionality::new_common().is_right_to_left(lang) {
-                    *style.make_direction_mut() = Direction::Rtl;
-                }
+        text_direction: {
+            if lang.is_some_and(|lang| LocaleDirectionality::new_common().is_right_to_left(lang)) {
+                Direction::Rtl
+            } else {
+                Direction::Ltr
             }
-            style
         },
         logset: LogOnceSet::new(),
     };
@@ -721,12 +763,10 @@ pub fn convert(
             crate::srv3::BodyElement::Window(id, window) => {
                 wname_to_index.insert(id, result.windows.len());
                 result.windows.push(window_builder.create_window(
-                    convert_coordinate(window.position.x as f32),
-                    convert_coordinate(window.position.y as f32),
+                    *window.position,
+                    *window.style,
                     window.time,
                     window.duration,
-                    window.position.point.to_alignment(),
-                    window.style.mode_hint,
                 ));
             }
             crate::srv3::BodyElement::Event(event) => {
@@ -749,12 +789,10 @@ pub fn convert(
                     window_builder.extend_lines(&mut result.windows[widx], &event);
                 } else {
                     let mut window = window_builder.create_window(
-                        convert_coordinate(event.position.x as f32),
-                        convert_coordinate(event.position.y as f32),
+                        *event.position,
+                        *event.style,
                         event.time,
                         event.duration,
-                        event.position.point.to_alignment(),
-                        event.style.mode_hint,
                     );
                     window_builder.extend_lines(&mut window, &event);
                     result.windows.push(window);

--- a/src/srv3/convert.rs
+++ b/src/srv3/convert.rs
@@ -211,6 +211,31 @@ struct LineSegment {
     annotation: Option<Segment>,
 }
 
+#[derive(Debug, Clone, Copy)]
+enum LayoutMode {
+    InlineBlock,
+    // TODO: fully inline mode could probably keep using blocks for ruby which would clean
+    //       up a sizing hack in inline layout
+    Inline,
+}
+
+impl crate::config::OptionFromStr for LayoutMode {
+    fn from_str(s: &str) -> Result<Self, util::AnyError> {
+        Ok(match s {
+            "inline-block" => Self::InlineBlock,
+            "inline" => Self::Inline,
+            _ => return Err("must be either \"inline-block\" or \"inline\"".into()),
+        })
+    }
+}
+
+crate::config::define_option_group! {
+    pub(crate) struct Options {
+        #[option(name = "layout-mode")]
+        layout_mode: LayoutMode = LayoutMode::InlineBlock,
+    }
+}
+
 impl Segment {
     fn compute_shadows(&self, ctx: &SubtitleContext, out: &mut Vec<TextShadow>) {
         let scale = FixedL::from_f32(font_scale_from_ctx(ctx) / 32.0);
@@ -301,7 +326,7 @@ impl VisualLine {
             }
         }
 
-        if pass.srv3_use_inlines {
+        if matches!(pass.cfg.srv3.layout_mode, LayoutMode::Inline) {
             *result.make_inline_sizing_mut() = InlineSizing::Stretch;
         }
 
@@ -390,7 +415,7 @@ impl VisualLine {
                             .map(|mut style| {
                                 // If inline-block layout is enabled then background is handled by the
                                 // containing block.
-                                if !pass.srv3_use_inlines {
+                                if matches!(pass.cfg.srv3.layout_mode, LayoutMode::InlineBlock) {
                                     *style.make_background_color_mut() = BGRA8::ZERO;
                                 }
                                 *style.make_font_size_mut() /= 2.0;
@@ -406,7 +431,7 @@ impl VisualLine {
                     }
                 };
 
-            if pass.srv3_use_inlines {
+            if matches!(pass.cfg.srv3.layout_mode, LayoutMode::Inline) {
                 if let Some(right_padding) = right_padding {
                     *style.make_padding_right_mut() = right_padding;
                 }

--- a/src/srv3/parse.rs
+++ b/src/srv3/parse.rs
@@ -37,44 +37,81 @@ pub enum RubyPosition {
     Under,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Pen {
-    pub font_size: u16,
-    pub font_style: u32,
+macro_rules! make_masked_struct {
+    (
+        $(#[$attr: meta])*
+        $vis: vis struct $name: ident {
+            $(#[setter = $fsname: ident] $fname: ident: $ftype: ty,)*
+        }
+    ) => {
+        $(#[$attr])*
+        $vis struct $name {
+            mask: u16,
+            $($fname: std::mem::MaybeUninit<$ftype>,)*
+        }
 
-    pub bold: bool,
-    pub italic: bool,
-    pub underline: bool,
+        impl $name {
+            $vis const EMPTY: Self = Self {
+                mask: 0,
+                $($fname: std::mem::MaybeUninit::uninit(),)*
+            };
 
-    pub edge_type: EdgeType,
-    pub edge_color: Option<u32>,
+            make_masked_struct!(@mkaccessors [1] $($fsname $fname: $ftype,)*);
+        }
 
-    pub ruby_part: RubyPart,
-
-    pub foreground_color: u32,
-    pub background_color: u32,
-}
-
-impl Pen {
-    pub const DEFAULT: Self = Self {
-        font_size: 100,
-        font_style: 0,
-        bold: false,
-        italic: false,
-        underline: false,
-        edge_type: EdgeType::None,
-        edge_color: None,
-        ruby_part: RubyPart::None,
-        foreground_color: 0xFFFFFFFF,
-        // The default opacity is 0.75
-        // round(0.75 * 255) = 0xBF
-        background_color: 0x080808BF,
+        impl PartialEq for $name {
+            fn eq(&self, other: &Self) -> bool {
+                self.mask == other.mask $(&& self.$fname() == other.$fname())*
+            }
+        }
     };
+    // this operates on an index and shifts later so that overflow is detected
+    (@mkaccessors [$i: expr] $fsname: ident $fname: ident: $ftype: ty, $($rest: tt)*) => {
+        pub const fn $fname(&self) -> Option<$ftype> {
+            // but just to be sure
+            const { assert!($i < 16); }
+
+            if self.mask & const { 1 << $i } != 0 {
+                Some(unsafe { self.$fname.assume_init() })
+            } else {
+                None
+            }
+        }
+
+        pub const fn $fsname(&mut self, value: $ftype) {
+            const {
+                const fn assert_is_copy<T: Copy>() {}
+                assert_is_copy::<$ftype>();
+            }
+
+            self.mask |= const { 1 << $i };
+            self.$fname.write(value);
+        }
+
+        make_masked_struct!(@mkaccessors [$i + 1] $($rest)*);
+    };
+    (@mkaccessors [$mask: expr]) => {};
 }
 
-impl Default for Pen {
-    fn default() -> Self {
-        Self::DEFAULT
+make_masked_struct! {
+    #[derive(Debug, Clone, Copy)]
+    pub struct Pen {
+        #[setter = set_font_size] font_size: u16,
+        #[setter = set_font_style] font_style: u32,
+
+        #[setter = set_bold] bold: bool,
+        #[setter = set_italic] italic: bool,
+        #[setter = set_underline] underline: bool,
+
+        #[setter = set_edge_type] edge_type: EdgeType,
+        #[setter = set_edge_color] edge_color: u32,
+
+        #[setter = set_ruby_part] ruby_part: RubyPart,
+
+        #[setter = set_foreground_color] foreground_color: u32,
+        #[setter = set_foreground_opacity] foreground_opacity: u8,
+        #[setter = set_background_color] background_color: u32,
+        #[setter = set_background_opacity] background_opacity: u8,
     }
 }
 
@@ -91,28 +128,13 @@ pub enum Point {
     BottomRight = 8,
 }
 
-#[derive(Debug, Clone)]
-pub struct WindowPos {
-    pub point: Point,
-    pub x: u32,
-    pub y: u32,
-}
-
-const DEFAULT_WINDOW_POS: WindowPos = WindowPos {
-    point: Point::BottomCenter,
-    x: 50,
-    y: 100,
-};
-
-impl Default for WindowPos {
-    fn default() -> Self {
-        DEFAULT_WINDOW_POS.clone()
+make_masked_struct! {
+    #[derive(Debug, Clone, Copy)]
+    pub struct WindowPos {
+        #[setter = set_point] point: Point,
+        #[setter = set_x] x: u32,
+        #[setter = set_y] y: u32,
     }
-}
-
-#[derive(Debug, Clone)]
-pub struct WindowStyle {
-    pub mode_hint: ModeHint,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -136,13 +158,10 @@ impl FromStr for ModeHint {
     }
 }
 
-const DEFAULT_WINDOW_STYLE: WindowStyle = WindowStyle {
-    mode_hint: ModeHint::Default,
-};
-
-impl Default for WindowStyle {
-    fn default() -> Self {
-        DEFAULT_WINDOW_STYLE
+make_masked_struct! {
+    #[derive(Debug, Clone, Copy)]
+    pub struct WindowStyle {
+        #[setter = set_mode_hint] mode_hint: ModeHint,
     }
 }
 
@@ -314,7 +333,7 @@ fn parse_pen(
     logset: &LogOnceSet,
 ) -> Result<(Box<str>, Pen), Error> {
     let mut result_id = None;
-    let mut result = Pen::default();
+    let mut result = Pen::EMPTY;
 
     log_once_state!(in logset; unknown_pen_attribute);
 
@@ -324,44 +343,40 @@ fn parse_pen(
             result_id = Some(id.into());
         },
         "fc"(color: HexRGBColor) => {
-            result.foreground_color &= 0x000000FF;
-            result.foreground_color |= color.0 << 8;
+            result.set_foreground_color(color.0);
         },
         "fo"(opacity: u8) => {
-            result.foreground_color &= 0xFFFFFF00;
-            result.foreground_color |= opacity as u32;
+            result.set_foreground_opacity(opacity);
         },
         "bc"(color: HexRGBColor) => {
-            result.background_color &= 0x000000FF;
-            result.background_color |= color.0 << 8;
+            result.set_background_color(color.0);
         },
         "bo"(opacity: u8) => {
-            result.background_color &= 0xFFFFFF00;
-            result.background_color |= opacity as u32;
+            result.set_background_opacity(opacity);
         },
         "ec"(color: HexRGBColor) => {
-            result.edge_color = Some(color.0);
+            result.set_edge_color(color.0);
         },
         "sz"(size: u16) => {
-            result.font_size = size;
+            result.set_font_size(size);
         },
         "fs"(style: u32) => {
-            result.font_style = style;
+            result.set_font_style(style);
         },
         "et"(et: EdgeType) => {
-            result.edge_type = et;
+            result.set_edge_type(et);
         },
         "i"(value: Bool01) => {
-            result.italic = value.0;
+            result.set_italic(value.0);
         },
         "b"(value: Bool01) => {
-            result.bold = value.0;
+            result.set_bold(value.0);
         },
         "u"(value: Bool01) => {
-            result.underline = value.0;
+            result.set_underline(value.0);
         },
         "rb"(value: RubyPart) => {
-            result.ruby_part = value;
+            result.set_ruby_part(value);
         },
         else other => {
             warn!(
@@ -384,7 +399,7 @@ fn parse_wp(
     logset: &LogOnceSet,
 ) -> Result<(Box<str>, WindowPos), Error> {
     let mut result_id = None;
-    let mut result = WindowPos::default();
+    let mut result = WindowPos::EMPTY;
 
     log_once_state!(in logset; unknown_wp_attribute);
 
@@ -394,13 +409,13 @@ fn parse_wp(
             result_id = Some(id.into());
         },
         "ap"(point: Point) => {
-            result.point = point;
+            result.set_point(point);
         },
         "ah"(x: u32) => {
-            result.x = x;
+            result.set_x(x);
         },
         "av"(y: u32) => {
-            result.y = y;
+            result.set_y(y);
         },
         else other => {
             warn!(
@@ -422,7 +437,7 @@ fn parse_ws(
     logset: &LogOnceSet,
 ) -> Result<(Box<str>, WindowStyle), Error> {
     let mut result_id = None;
-    let mut result = WindowStyle::default();
+    let mut result = WindowStyle::EMPTY;
 
     log_once_state!(in logset; unknown_ws_attribute);
 
@@ -432,7 +447,7 @@ fn parse_ws(
             result_id = Some(id.into());
         },
         "mh"(mh: ModeHint) => {
-            result.mode_hint = mh;
+            result.set_mode_hint(mh);
         },
         else other => {
             warn!(
@@ -564,7 +579,7 @@ impl<'rs> BodyParser<'rs> {
             };
         }
 
-        let mut current_event_pen = &Pen::DEFAULT;
+        let mut current_event_pen = &Pen::EMPTY;
         let mut current_segment_pen = current_event_pen;
         let mut current_segment_time_offset = 0;
         let mut current_text = String::new();
@@ -579,8 +594,8 @@ impl<'rs> BodyParser<'rs> {
                             let mut result = Window {
                                 time: 0,
                                 duration: u32::MAX,
-                                position: &DEFAULT_WINDOW_POS,
-                                style: &DEFAULT_WINDOW_STYLE,
+                                position: &WindowPos::EMPTY,
+                                style: &WindowStyle::EMPTY,
                             };
 
                             match_attributes! {
@@ -621,13 +636,13 @@ impl<'rs> BodyParser<'rs> {
                             let mut result = Event {
                                 time: 0,
                                 duration: 0,
-                                position: &DEFAULT_WINDOW_POS,
-                                style: &DEFAULT_WINDOW_STYLE,
+                                position: &WindowPos::EMPTY,
+                                style: &WindowStyle::EMPTY,
                                 window_id: None,
                                 segments: vec![],
                             };
 
-                            current_event_pen = &Pen::DEFAULT;
+                            current_event_pen = &Pen::EMPTY;
 
                             match_attributes! {
                                 element.attributes(),


### PR DESCRIPTION
Currently subrandr is not very customizable (read: not at all customizable). The lack of a configuration API also means I have to restart mpv and change an env var every time I want to enable some debugging overlay too which gets annoying after a while.

So this PR adds an option-based API that exposes a single "config" struct which holds option values and allows setting them via string keys and values.

This is slightly similar to libplacebo (and even more slightly to ffmpeg) with the main difference being that there is no other way to change the option in a more type-safe manner. I don't think providing one makes sense here, these options are meant to be mostly "customization" options so unlikely to make sense outside of "set some defaults" or "pass down configuration from the user".

The initial idea for stability is that I document what options are "unstable/expected to change" and options not classified as such would be "reasonably stable". Specifically don't want to rule out the possibility of renaming or removing options (ideally with an alias for some time after renaming and a deprecation period before removing).
Not sure how such an alias would look if an iteration API is added though (and it's probably better to consider that before adding one?).

---

TODO (lots of bikes to shed):
- [ ] snake_case or kebab-case for option names? libplacebo and ffmpeg use snake_case but I kinda don't like it, I would expect it shouldn't matter much but at the same time maybe it's better to be more consistent within the ecosystem even if I personally prefer kebab-case
- [ ] Finish C API
- [x] Write documentation (something like an `OPTIONS.md`)
- [x] Write mpv implementation for a `subrandr-opts` option
- (future work) Is an API for iterating the available options necessary? I think it'd be nice to have but not sure exactly how it should look.