### PR TITLE
Replace unstable error code API with meaningful return values

### DIFF
--- a/include/subrandr.h
+++ b/include/subrandr.h
@@ -12,22 +12,6 @@ extern "C" {
 #include <stdint.h>
 #endif
 
-#ifdef SBR_ALLOW_UNSTABLE
-#define SBR_UNSTABLE
-// clang implements this attribute sensibly and doesn't cause unavailable errors
-// if an unavailable type is only used in other unavailable declarations.
-// GCC does not have these semantics and I'm scared of what other compilers
-// might do here.
-#elif defined(__has_attribute) && defined(__clang__)
-#if __has_attribute(unavailable)
-#define SBR_UNSTABLE                                                           \
-  __attribute__((                                                              \
-      unavailable("This item is not part of subrandr's stable API yet. "       \
-                  "Define SBR_ALLOW_UNSTABLE before including subrandr.h if "  \
-                  "you still want to use it.")))
-#endif
-#endif
-
 #define SUBRANDR_MAJOR SUBRANDR_MAJOR_PLACEHOLDER
 #define SUBRANDR_MINOR SUBRANDR_MINOR_PLACEHOLDER
 #define SUBRANDR_PATCH SUBRANDR_PATCH_PLACEHOLDER
@@ -205,20 +189,11 @@ void sbr_instanced_raster_pass_finish(sbr_instanced_raster_pass *);
 
 void sbr_renderer_destroy(sbr_renderer *);
 
-#ifdef SBR_UNSTABLE
-typedef uint32_t SBR_UNSTABLE sbr_error_code;
-#define SBR_ERR_OTHER (sbr_error_code)1
-#define SBR_ERR_IO (sbr_error_code)2
-#define SBR_ERR_INVALID_ARGUMENT (sbr_error_code)3
-#define SBR_ERR_UNRECOGNIZED_FORMAT (sbr_error_code)10
-#endif
-
+// Get the error message of the last error that occurred on the current thread.
+// The returned string will be valid until another error occurs on this thread.
+//
+// Returns `NULL` if no error has occurred on this thread yet.
 char const *sbr_get_last_error_string(void);
-#ifdef SBR_UNSTABLE
-SBR_UNSTABLE uint32_t sbr_get_last_error_code(void);
-#endif
-
-#undef SBR_UNSTABLE
 
 #ifdef __cplusplus
 }

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -47,13 +47,12 @@ macro_rules! c_enum {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(i16)]
 enum ErrorKind {
-    Other = 1,
-    InvalidArgument = 2,
-    Io = 3,
+    Other = -1,
+    InvalidArgument = -2,
 
-    UnrecognizedFormat = 10,
+    UnrecognizedFormat = -11,
 }
 
 #[derive(Debug)]
@@ -85,19 +84,8 @@ impl CError {
     }
 
     pub fn from_error(error: impl std::error::Error + Sync + 'static) -> Self {
-        let mut root_cause = &error as &dyn std::error::Error;
-        while let Some(cause) = root_cause.source() {
-            root_cause = cause;
-        }
-
-        let kind = if root_cause.is::<std::io::Error>() {
-            ErrorKind::Io
-        } else {
-            ErrorKind::Other
-        };
-
         Self {
-            kind,
+            kind: ErrorKind::Other,
             context: Some(Box::new(error)),
             message: None,
         }
@@ -122,7 +110,6 @@ impl std::fmt::Display for CError {
 impl std::error::Error for CError {}
 
 struct LastError {
-    error: CError,
     string: CString,
 }
 
@@ -134,40 +121,41 @@ fn fill_last_error(error: CError) {
     LAST_ERROR.with(|x| unsafe {
         (*x.get()) = Some(LastError {
             string: CString::new(error.to_string()).unwrap(),
-            error,
         });
     })
 }
 
-struct CErrorValue;
+trait CErrorReturn {
+    fn from(err: &CError) -> Self;
+}
 
-impl<T> From<CErrorValue> for *mut T {
-    fn from(_: CErrorValue) -> Self {
+impl<T> CErrorReturn for *mut T {
+    fn from(_: &CError) -> Self {
         std::ptr::null_mut()
     }
 }
 
-impl<T> From<CErrorValue> for *const T {
-    fn from(_: CErrorValue) -> Self {
+impl<T> CErrorReturn for *const T {
+    fn from(_: &CError) -> Self {
         std::ptr::null()
     }
 }
 
-impl From<CErrorValue> for i64 {
-    fn from(_: CErrorValue) -> Self {
-        -1
+impl CErrorReturn for i64 {
+    fn from(e: &CError) -> Self {
+        e.kind as _
     }
 }
 
-impl From<CErrorValue> for i32 {
-    fn from(_: CErrorValue) -> Self {
-        -1
+impl CErrorReturn for i32 {
+    fn from(e: &CError) -> Self {
+        e.kind as _
     }
 }
 
-impl From<CErrorValue> for i16 {
-    fn from(_: CErrorValue) -> Self {
-        -1
+impl CErrorReturn for i16 {
+    fn from(e: &CError) -> Self {
+        e.kind as _
     }
 }
 
@@ -195,8 +183,12 @@ fn probe(content: &str) -> SubtitleFormat {
 
 macro_rules! cthrow {
     ($error: expr) => {{
-        $crate::capi::fill_last_error($error);
-        return $crate::capi::CErrorValue.into();
+        return {
+            let error = $error;
+            let ret = $crate::capi::CErrorReturn::from(&error);
+            $crate::capi::fill_last_error(error);
+            ret
+        };
     }};
     ($kind: ident, $message: expr) => {
         cthrow!($crate::capi::CError::new(
@@ -328,11 +320,6 @@ unsafe extern "C" fn sbr_get_last_error_string() -> *const c_char {
             .as_ref()
             .map_or(std::ptr::null(), |e| e.string.as_ptr())
     })
-}
-
-#[unsafe(no_mangle)]
-unsafe extern "C" fn sbr_get_last_error_code() -> u32 {
-    LAST_ERROR.with(|x| (*x.get()).as_ref().map_or(0, |e| e.error.kind as u32))
 }
 
 #[unsafe(no_mangle)]


### PR DESCRIPTION
Improvement pulled out from https://github.com/afishhh/subrandr/pull/162.

No error values are actually defined in the C headers so this doesn't introduce public API.