### PR TITLE
Switch `GlyphString` to logical glyph order

### DIFF
--- a/src/layout/inline.rs
+++ b/src/layout/inline.rs
@@ -732,11 +732,7 @@ impl RunShaper<'_> {
             };
 
             let initial_cluster_utf8_index = self.font_feature_events[idx].utf8_index;
-            loop {
-                let Some(prev_idx) = idx.checked_sub(1) else {
-                    break;
-                };
-
+            while let Some(prev_idx) = idx.checked_sub(1) {
                 if self.font_feature_events[prev_idx].utf8_index != initial_cluster_utf8_index {
                     break;
                 }
@@ -1497,11 +1493,7 @@ impl ShapedItemText {
         let text = self.glyphs.text();
         let mut break_start_index = opportunity;
         let mut break_end_index = opportunity;
-        loop {
-            let Some(prev) = break_start_index.checked_sub(1) else {
-                break;
-            };
-
+        while let Some(prev) = break_start_index.checked_sub(1) {
             if text.as_bytes()[prev] == b' ' {
                 break_start_index = prev;
             } else {

--- a/src/layout/inline.rs
+++ b/src/layout/inline.rs
@@ -199,7 +199,7 @@ impl<'a> InlineSpanBuilder<'a> {
         let content_index = self.push_object_replacement();
         self.push_child(InlineItem::Block(InlineBlock {
             content_index,
-            block,
+            block: Box::new(block),
         }));
         self.last_item_is_text = false;
     }
@@ -286,7 +286,7 @@ pub struct InlineText {
 #[derive(Debug, Clone)]
 pub struct InlineBlock {
     content_index: usize,
-    block: BlockContainer,
+    block: Box<BlockContainer>,
 }
 
 #[derive(Debug)]

--- a/src/layout/inline.rs
+++ b/src/layout/inline.rs
@@ -1,3 +1,4 @@
+use core::{convert::AsRef, iter::Iterator};
 use std::{ops::Range, rc::Rc};
 
 use icu_segmenter::{options::LineBreakOptions, GraphemeClusterSegmenter};
@@ -434,6 +435,28 @@ struct LeafItemRange<'a> {
     range: Range<usize>,
     span_id: usize,
     style: &'a ComputedStyle,
+}
+
+impl AsRef<Range<usize>> for LeafItemRange<'_> {
+    fn as_ref(&self) -> &Range<usize> {
+        &self.range
+    }
+}
+
+pub fn slice_sorted_ranges_intersecting<E: AsRef<Range<usize>>>(
+    ranges: &[E],
+    range: Range<usize>,
+) -> &[E] {
+    let start = match ranges.binary_search_by_key(&range.start, |e| e.as_ref().end) {
+        Ok(s) => s + 1,
+        Err(s) => s,
+    };
+    let end = match ranges[start..].binary_search_by_key(&range.end, |e| e.as_ref().start) {
+        Ok(s) => s,
+        Err(s) => s,
+    } + start;
+
+    &ranges[start..end]
 }
 
 #[derive(Debug)]
@@ -1599,66 +1622,49 @@ fn layout_run_full<'a>(
     ) -> Result<(), InlineLayoutError> {
         let mut glyphs = shaped.glyphs.clone();
 
-        // TODO: Simplify this code, it's kind of hacky at the moment.
+        let mut intersecting_leaves = slice_sorted_ranges_intersecting(leaves, range.clone());
+        if intersecting_leaves.is_empty() {
+            // FIXME: This is only necessary because empty lines currently create empty text items
+            //        Instead explicit breaks should probably handled in another way
+            return Ok(());
+        } else if intersecting_leaves.len() == 1 {
+            push_section(&intersecting_leaves[0], glyphs, range.clone())?;
+            return Ok(());
+        }
+
         if !glyphs.direction().is_reverse() {
-            let mut si = match leaves.binary_search_by_key(&range.start, |l| l.range.start) {
-                Ok(s) => s,
-                Err(s) => s - 1,
-            };
-
-            if leaves
-                .get(si + 1)
-                .is_none_or(|l| l.range.start >= range.end)
-            {
-                push_section(&leaves[si], glyphs, range.clone())?;
-                return Ok(());
-            }
-
-            let mut i = range.start;
-            while i != range.end {
-                let end = leaves
-                    .get(si + 1)
-                    .map(|l| l.range.start.min(range.end))
-                    .unwrap_or(range.end);
+            let mut start = range.start;
+            while start != range.end {
+                let (leaf, rest) = intersecting_leaves.split_first().unwrap();
+                intersecting_leaves = rest;
+                let end = if intersecting_leaves.is_empty() {
+                    range.end
+                } else {
+                    leaf.range.end
+                };
 
                 if let Some(section_glyphs) = glyphs.split_off_visual_start(end) {
-                    push_section(&leaves[si], section_glyphs, i..end)?;
+                    push_section(leaf, section_glyphs, start..end)?;
                 }
 
-                i = end;
-                si += 1;
+                start = end;
             }
         } else {
-            let mut si = match leaves.binary_search_by_key(&range.end, |l| l.range.start) {
-                Ok(s) => s.saturating_sub(1),
-                Err(s) => s - 1,
-            };
-
-            if leaves[si].range.start <= range.start {
-                push_section(&leaves[si], glyphs, range.clone())?;
-                return Ok(());
-            }
-
-            let mut i = range.end;
-            while i != range.start {
-                let ref leaf @ LeafItemRange {
-                    range: Range { start, .. },
-                    ..
-                } = leaves[si];
-                let start = start.max(range.start);
+            let mut end = range.end;
+            while end != range.start {
+                let (leaf, rest) = intersecting_leaves.split_last().unwrap();
+                intersecting_leaves = rest;
+                let start = if intersecting_leaves.is_empty() {
+                    range.start
+                } else {
+                    leaf.range.start
+                };
 
                 if let Some(section_glyphs) = glyphs.split_off_visual_start(start) {
-                    push_section(leaf, section_glyphs, start..i)?;
+                    push_section(leaf, section_glyphs, start..end)?;
                 }
 
-                i = start;
-                si = match si.checked_sub(1) {
-                    Some(i) => i,
-                    None => {
-                        debug_assert_eq!(i, range.start);
-                        break;
-                    }
-                }
+                end = start;
             }
         };
 
@@ -2205,30 +2211,19 @@ fn layout_run_full<'a>(
         ) {
             match &item.kind {
                 ShapedItemKind::Text(_) => {
-                    // TODO: deduplicate this with split_on_leaves rtl branch
-                    //       (this is the same thing sans splitting glyphs)
-                    let mut si =
-                        match leaves.binary_search_by_key(&item.range.end, |l| l.range.start) {
-                            Ok(s) => s.saturating_sub(1),
-                            Err(s) => s - 1,
+                    let mut intersecting_leaves =
+                        slice_sorted_ranges_intersecting(leaves, item.range.clone());
+                    let mut start = item.range.start;
+                    while start != item.range.end {
+                        let (leaf, rest) = intersecting_leaves.split_first().unwrap();
+                        intersecting_leaves = rest;
+                        if intersecting_leaves.is_empty() {
+                            on_leaf(leaf.span_id, start..item.range.end);
+                            break;
+                        } else {
+                            on_leaf(leaf.span_id, start..leaf.range.end);
+                            start = leaf.range.end;
                         };
-
-                    if leaves[si].range.start <= item.range.start {
-                        return on_leaf(leaves[si].span_id, item.range.clone());
-                    }
-
-                    let mut i = item.range.end;
-                    while i != item.range.start {
-                        let ref leaf @ LeafItemRange {
-                            range: Range { start, .. },
-                            ..
-                        } = leaves[si];
-                        let start = start.max(item.range.start);
-
-                        on_leaf(leaf.span_id, start..i);
-
-                        i = start;
-                        si = si.wrapping_sub(1);
                     }
                 }
                 ShapedItemKind::Ruby(ruby) => on_leaf(ruby.span_id, item.range.clone()),

--- a/src/layout/inline.rs
+++ b/src/layout/inline.rs
@@ -1536,11 +1536,7 @@ impl ShapedItemText {
             if *current_width > ctx.constraints.size.x {
                 // We want to also consider breaking within the current glyph so let's
                 // start looking for break opportunities anywhere before the *next* glyph.
-                let glyph_end = if self.glyphs.direction().is_reverse() {
-                    glyph.cluster + 1
-                } else {
-                    glyph_it.peek().map(|(_, g)| g.cluster).unwrap_or(range.end)
-                };
+                let glyph_end = glyph.cluster + 1;
                 let opportunities = &ctx.break_opportunities[..match ctx
                     .break_opportunities
                     .binary_search(&glyph_end)
@@ -1720,39 +1716,40 @@ fn layout_run_full<'a>(
                             "bidi reordering attempted to partially reorder a text item on both sides"
                         );
 
-                        // Cursed code path™
-                        // I doubt even god knows whether this works in all cases,
-                        // it works in at least one though.
-                        // HACK: This can only happen due to bidi rule L1 which may split a line's
-                        // trailing whitespace into a separate level run.
-                        // Since this may only occur with whitespaces we cheat a little bit here and
-                        // just completely unsafely split glyph strings assuming no reshaping is
-                        // necessary. Reshaping here would be a bad idea anyway and doesn't make sense.
+                        // This case happens when bidi rule L1 reorders some whitespace inside a bidi
+                        // level run.
+                        // Since this is only supposed to affect whitespace glyphs, we don't reshape here
+                        // assuming that the font is sane and does not ligate spaces. If it's not sane
+                        // in this way, then true theoreteically correct line-breaking requires unbounded
+                        // backtracking so it's not like we have much of a choice.
+
                         let mut tmp = ShapedItemText {
                             font_matcher: text.font_matcher.clone(),
                             primary_font: text.primary_font.clone(),
                             glyphs: text.glyphs.clone(),
                             break_after: false,
                         };
-                        if range.start > item.range.start {
-                            tmp.glyphs.split_off_visual_start(range.start);
+                        let split_range = if range.start > item.range.start {
+                            tmp.glyphs.split_off_logical_end(range.start).map(|after| {
+                                tmp.glyphs = after;
+                                range.start..item.range.end
+                            })
+                        } else {
+                            debug_assert!(range.end < item.range.end);
+                            tmp.glyphs.split_off_logical_start(range.end).map(|before| {
+                                tmp.glyphs = before;
+                                item.range.start..range.end
+                            })
+                        };
+
+                        if let Some(split_range) = split_range {
                             push_item(&mut ShapedItem {
-                                range: range.start..item.range.end,
+                                range: split_range,
                                 kind: ShapedItemKind::Text(tmp),
                                 padding: ShapedItemPadding::MAX,
                             })
                         } else {
-                            debug_assert!(range.end < item.range.end);
-                            if let Some(before) = tmp.glyphs.split_off_visual_start(range.end) {
-                                tmp.glyphs = before;
-                                push_item(&mut ShapedItem {
-                                    range: item.range.start..range.end,
-                                    kind: ShapedItemKind::Text(tmp),
-                                    padding: ShapedItemPadding::MAX,
-                                })
-                            } else {
-                                Ok(())
-                            }
+                            Ok(())
                         }
                     } else {
                         unreachable!(
@@ -1864,7 +1861,7 @@ fn layout_run_full<'a>(
                             primary_metrics.descender - half_leading,
                         );
 
-                        for font in text.glyphs.iter_fonts_visual() {
+                        for font in text.glyphs.iter_fonts_logical() {
                             self.expand_to(
                                 font.metrics().ascender + half_leading,
                                 font.metrics().descender - half_leading,

--- a/src/layout/inline.rs
+++ b/src/layout/inline.rs
@@ -674,73 +674,93 @@ enum FontFeatureEventKind {
     Reset,
 }
 
-fn set_buffer_content_from_range(
-    buffer: &mut ShapingBuffer,
-    text: &str,
-    range: Range<usize>,
-    font_feature_events: &[FontFeatureEvent],
-    grapheme_cluster_boundaries: &[usize],
-) {
-    buffer.set_pre_context(&text[..range.start]);
+struct RunShaper<'a> {
+    buffer: &'a mut ShapingBuffer,
+    font_feature_events: &'a [FontFeatureEvent],
+    grapheme_cluster_boundaries: &'a [usize],
+}
 
-    let next_grapheme_boundary_idx = match grapheme_cluster_boundaries.binary_search(&range.start) {
-        Ok(i) => i + 1,
-        Err(i) => i,
-    };
-    let mut next_grapheme_boundary_it = grapheme_cluster_boundaries[next_grapheme_boundary_idx..]
-        .iter()
-        .copied();
+impl RunShaper<'_> {
+    fn set_buffer_content(&mut self, text: &str, range: Range<usize>, direction: Direction) {
+        self.buffer.clear();
+        self.buffer.set_direction(direction);
+        self.buffer.set_pre_context(&text[..range.start]);
 
-    let mut next_feature_ev_idx = 'feature_idx: {
-        let mut idx = match font_feature_events.binary_search_by_key(&range.start, |f| f.utf8_index)
-        {
-            Ok(i) => i,
-            Err(i) => match i.checked_sub(1) {
-                Some(prev) => prev,
-                None => break 'feature_idx i,
-            },
-        };
+        let next_grapheme_boundary_idx =
+            match self.grapheme_cluster_boundaries.binary_search(&range.start) {
+                Ok(i) => i + 1,
+                Err(i) => i,
+            };
+        let mut next_grapheme_boundary_it = self.grapheme_cluster_boundaries
+            [next_grapheme_boundary_idx..]
+            .iter()
+            .copied();
 
-        let initial_cluster_utf8_index = font_feature_events[idx].utf8_index;
-        loop {
-            let Some(prev_idx) = idx.checked_sub(1) else {
-                break;
+        let mut next_feature_ev_idx = 'feature_idx: {
+            let mut idx = match self
+                .font_feature_events
+                .binary_search_by_key(&range.start, |f| f.utf8_index)
+            {
+                Ok(i) => i,
+                Err(i) => match i.checked_sub(1) {
+                    Some(prev) => prev,
+                    None => break 'feature_idx i,
+                },
             };
 
-            if font_feature_events[prev_idx].utf8_index != initial_cluster_utf8_index {
-                break;
-            }
+            let initial_cluster_utf8_index = self.font_feature_events[idx].utf8_index;
+            loop {
+                let Some(prev_idx) = idx.checked_sub(1) else {
+                    break;
+                };
 
-            idx = prev_idx;
-        }
-
-        idx
-    };
-
-    let mut current = range.start;
-    while current != range.end {
-        loop {
-            match font_feature_events.get(next_feature_ev_idx) {
-                Some(event) if event.utf8_index <= current => {
-                    match event.kind {
-                        FontFeatureEventKind::Set(tag, value) => buffer.set_feature(tag, value),
-                        FontFeatureEventKind::Reset => buffer.reset_features(),
-                    }
-
-                    next_feature_ev_idx += 1;
+                if self.font_feature_events[prev_idx].utf8_index != initial_cluster_utf8_index {
+                    break;
                 }
-                _ => break,
+
+                idx = prev_idx;
             }
+
+            idx
+        };
+
+        let mut current = range.start;
+        while current != range.end {
+            loop {
+                match self.font_feature_events.get(next_feature_ev_idx) {
+                    Some(event) if event.utf8_index <= current => {
+                        match event.kind {
+                            FontFeatureEventKind::Set(tag, value) => {
+                                self.buffer.set_feature(tag, value)
+                            }
+                            FontFeatureEventKind::Reset => self.buffer.reset_features(),
+                        }
+
+                        next_feature_ev_idx += 1;
+                    }
+                    _ => break,
+                }
+            }
+
+            let end = next_grapheme_boundary_it
+                .next()
+                .map_or(range.end, |end| end.min(range.end));
+            self.buffer.add_grapheme(&text[current..end], current);
+            current = end;
         }
 
-        let end = next_grapheme_boundary_it
-            .next()
-            .map_or(range.end, |end| end.min(range.end));
-        buffer.add_grapheme(&text[current..end], current);
-        current = end;
+        self.buffer.set_post_context(&text[range.end..]);
     }
 
-    buffer.set_post_context(&text[range.end..]);
+    pub fn shape(
+        &mut self,
+        output: &mut dyn text::ShapingSink,
+        font_iterator: text::FontMatchIterator<'_>,
+        lctx: &mut LayoutContext,
+    ) -> Result<(), text::ShapingError> {
+        self.buffer
+            .shape(lctx.log, output, font_iterator, lctx.fonts)
+    }
 }
 
 fn shape_run_initial<'a>(
@@ -765,10 +785,8 @@ fn shape_run_initial<'a>(
             bidi: &unicode_bidi::BidiInfo,
             lctx: &mut LayoutContext,
             result: &mut Vec<ShapedItem<'_>>,
-            font_features_events: &[FontFeatureEvent],
             left_padding: &mut FixedL,
-            buffer: &mut ShapingBuffer,
-            grapheme_cluster_boundaries: &[usize],
+            shaper: &mut RunShaper,
         ) -> Result<(), InlineLayoutError> {
             let mut current_paragraph = match bidi
                 .paragraphs
@@ -789,20 +807,13 @@ fn shape_run_initial<'a>(
                 };
 
                 let glyphs = {
-                    buffer.guess_properties();
-                    buffer.set_direction(direction.to_horizontal());
-                    set_buffer_content_from_range(
-                        buffer,
-                        &text,
-                        range.clone(),
-                        font_features_events,
-                        grapheme_cluster_boundaries,
-                    );
+                    shaper.buffer.guess_properties();
+                    shaper.set_buffer_content(&text, range.clone(), direction);
                     let mut output = GlyphString::new(text.clone(), direction);
-                    buffer.shape(lctx.log, &mut output, self.matcher.iterator(), lctx.fonts)?;
+                    shaper.shape(&mut output, self.matcher.iterator(), lctx)?;
                     output
                 };
-                buffer.clear();
+                shaper.buffer.clear();
 
                 result.push(ShapedItem {
                     range: range.clone(),
@@ -977,6 +988,25 @@ fn shape_run_initial<'a>(
             }
         }
 
+        fn flush_queued_text(&mut self) -> Result<(), InlineLayoutError> {
+            if let Some(queued) = self.queued_text.take() {
+                queued.flush(
+                    self.run_text.clone(),
+                    &self.bidi,
+                    self.lctx,
+                    &mut self.shaped,
+                    &mut self.queued_padding,
+                    &mut RunShaper {
+                        buffer: &mut self.shaping_buffer,
+                        font_feature_events: &self.font_feature_events,
+                        grapheme_cluster_boundaries: &self.grapheme_cluster_boundaries,
+                    },
+                )?;
+            }
+
+            Ok(())
+        }
+
         fn handle_span_start(&mut self, style: &'a ComputedStyle) -> Result<(), InlineLayoutError> {
             let left_padding = style.padding_left().to_physical_pixels(self.lctx.dpi);
 
@@ -988,18 +1018,7 @@ fn shape_run_initial<'a>(
                 //       trigger a `QueuedText::flush` and shaping break.
                 //       The only exception is right-side cloned padding which needs to be communicated
                 //       via a side-channel because it may differ inside a single `ShapedItem`.
-                if let Some(queued) = self.queued_text.take() {
-                    queued.flush(
-                        self.run_text.clone(),
-                        &self.bidi,
-                        self.lctx,
-                        &mut self.shaped,
-                        &self.font_feature_events,
-                        &mut self.queued_padding,
-                        &mut self.shaping_buffer,
-                        &self.grapheme_cluster_boundaries,
-                    )?;
-                }
+                self.flush_queued_text()?;
 
                 self.queued_padding += left_padding;
             }
@@ -1039,18 +1058,7 @@ fn shape_run_initial<'a>(
             let right_padding = style.padding_right().to_physical_pixels(self.lctx.dpi);
 
             if right_padding != FixedL::ZERO {
-                if let Some(queued) = self.queued_text.take() {
-                    queued.flush(
-                        self.run_text.clone(),
-                        &self.bidi,
-                        self.lctx,
-                        &mut self.shaped,
-                        &self.font_feature_events,
-                        &mut self.queued_padding,
-                        &mut self.shaping_buffer,
-                        &self.grapheme_cluster_boundaries,
-                    )?;
-                }
+                self.flush_queued_text()?;
 
                 if let Some(item) = self.shaped.last_mut() {
                     item.padding.current_padding_right += right_padding;
@@ -1097,18 +1105,7 @@ fn shape_run_initial<'a>(
                             span_left = span.length;
                         }
                         InlineSpanKind::Ruby { content_index } => {
-                            if let Some(queued) = self.queued_text.take() {
-                                queued.flush(
-                                    self.run_text.clone(),
-                                    &self.bidi,
-                                    self.lctx,
-                                    &mut self.shaped,
-                                    &self.font_feature_events,
-                                    &mut self.queued_padding,
-                                    &mut self.shaping_buffer,
-                                    &self.grapheme_cluster_boundaries,
-                                )?;
-                            }
+                            self.flush_queued_text()?;
 
                             let content_end = content_index + OBJECT_REPLACEMENT_LENGTH;
                             self.shaped.push(ShapedItem {
@@ -1233,17 +1230,8 @@ fn shape_run_initial<'a>(
                             {
                                 queued.range.end = text.content_range.end
                             }
-                            Some(queued) => {
-                                queued.flush(
-                                    self.run_text.clone(),
-                                    &self.bidi,
-                                    self.lctx,
-                                    &mut self.shaped,
-                                    &self.font_feature_events,
-                                    &mut self.queued_padding,
-                                    &mut self.shaping_buffer,
-                                    &self.grapheme_cluster_boundaries,
-                                )?;
+                            Some(_) => {
+                                self.flush_queued_text()?;
                                 self.queued_text = Some(QueuedText {
                                     matcher: font_matcher,
                                     range: text.content_range.clone(),
@@ -1295,18 +1283,7 @@ fn shape_run_initial<'a>(
                         content_index,
                         ref block,
                     }) => {
-                        if let Some(queued) = self.queued_text.take() {
-                            queued.flush(
-                                self.run_text.clone(),
-                                &self.bidi,
-                                self.lctx,
-                                &mut self.shaped,
-                                &self.font_feature_events,
-                                &mut self.queued_padding,
-                                &mut self.shaping_buffer,
-                                &self.grapheme_cluster_boundaries,
-                            )?;
-                        }
+                        self.flush_queued_text()?;
 
                         let content_end = content_index + OBJECT_REPLACEMENT_LENGTH;
                         self.shaped.push(ShapedItem {
@@ -1345,18 +1322,7 @@ fn shape_run_initial<'a>(
             }
             *end_item_index = current_item;
 
-            if let Some(queued) = self.queued_text {
-                queued.flush(
-                    self.run_text.clone(),
-                    &self.bidi,
-                    self.lctx,
-                    &mut self.shaped,
-                    &self.font_feature_events,
-                    &mut self.queued_padding,
-                    &mut self.shaping_buffer,
-                    &self.grapheme_cluster_boundaries,
-                )?;
-            }
+            self.flush_queued_text()?;
 
             debug_assert!(compute_break_opportunities || self.break_opportunities.is_empty());
 
@@ -1414,9 +1380,7 @@ struct BreakingContext<'l, 'a> {
     layout: &'a mut LayoutContext<'l>,
     constraints: &'a LayoutConstraints,
     break_opportunities: &'a [usize],
-    break_buffer: text::ShapingBuffer,
-    font_feature_events: &'a [FontFeatureEvent],
-    grapheme_cluster_boundaries: &'a [usize],
+    shaper: RunShaper<'a>,
 }
 
 #[derive(Debug)]
@@ -1576,9 +1540,7 @@ impl ShapedItemText {
                     if let Some((broken, remaining)) = self.glyphs.break_around(
                         break_range,
                         ctx.constraints.size.x - initial_x,
-                        &mut ctx.break_buffer,
-                        ctx.font_feature_events,
-                        ctx.grapheme_cluster_boundaries,
+                        &mut ctx.shaper,
                         self.font_matcher.iterator(),
                         ctx.layout,
                     )? {
@@ -2445,9 +2407,11 @@ fn layout_run_full<'a>(
             layout: lctx,
             constraints,
             break_opportunities: &break_opportunities,
-            break_buffer: text::ShapingBuffer::new(),
-            font_feature_events: &font_feature_events,
-            grapheme_cluster_boundaries: &grapheme_cluster_boundaries,
+            shaper: RunShaper {
+                buffer: &mut text::ShapingBuffer::new(),
+                font_feature_events: &font_feature_events,
+                grapheme_cluster_boundaries: &grapheme_cluster_boundaries,
+            },
         };
 
         'break_loop: loop {

--- a/src/layout/inline/glyph_string.rs
+++ b/src/layout/inline/glyph_string.rs
@@ -30,9 +30,16 @@ impl Debug for GlyphString {
                 f.debug_struct("GlyphStringSegment")
                     .field("text", &&self.text[segment.text_range.clone()])
                     .field("font", &&segment.font)
+                    .field("text_range", &&segment.text_range)
                     .field(
                         "glyphs",
-                        &util::fmt_from_fn(|f| f.debug_list().finish_non_exhaustive()),
+                        &util::fmt_from_fn(|f| {
+                            let mut list = f.debug_list();
+                            for glyph in segment {
+                                list.entry(glyph);
+                            }
+                            list.finish()
+                        }),
                     )
                     .finish()
             }));
@@ -72,10 +79,11 @@ impl<'s> IntoIterator for &'s GlyphStringSegment {
 }
 
 impl GlyphStringSegment {
-    fn subslice(&self, range: Range<usize>, direction: Direction) -> Self {
+    #[track_caller]
+    fn subslice(&self, range: Range<usize>) -> Self {
         assert!(
             range.start < range.end,
-            "Invalid glyph string segment subslice ({} > {})",
+            "Invalid glyph string segment subslice ({} >= {})",
             range.start,
             range.end
         );
@@ -83,18 +91,10 @@ impl GlyphStringSegment {
         Self {
             storage: self.storage.clone(),
             glyph_range: self.glyph_range.start + range.start..self.glyph_range.start + range.end,
-            text_range: {
-                if !direction.is_reverse() {
-                    self[range.start].cluster
-                        ..self
-                            .get(range.end)
-                            .map_or(self.text_range.end, |g| g.cluster)
-                } else {
-                    self.get(range.end)
-                        .map_or(self.text_range.start, |g| g.cluster + 1)
-                        ..self[range.start].cluster + 1
-                }
-            },
+            text_range: self[range.start].cluster
+                ..self
+                    .get(range.end)
+                    .map_or(self.text_range.end, |g| g.cluster),
             font: self.font.clone(),
         }
     }
@@ -102,101 +102,48 @@ impl GlyphStringSegment {
     // [`Self::subslice`] does not allow creating an empty subslice so that "no empty segments"
     // can be an invariant upheld by [`GlyphString`].
     // This function allows for empty subslices but returns them as an empty [`LinkedList`].
-    fn subslice_into_vec(&self, range: Range<usize>, direction: Direction) -> Vec<Self> {
+    fn subslice_into_vec(&self, range: Range<usize>) -> Vec<Self> {
         if range.start == range.end {
             return Vec::new();
         }
 
-        Vec::from([self.subslice(range, direction)])
+        Vec::from([self.subslice(range)])
     }
 
-    fn split_off_visual_start(&mut self, pivot: usize, direction: Direction) -> Self {
-        let result = self.subslice(0..pivot, direction);
+    fn split_off_logical_start(&mut self, pivot: usize) -> Self {
+        let result = self.subslice(0..pivot);
         self.glyph_range.start += pivot;
-        if !direction.is_reverse() {
-            self.text_range.start = result.text_range.end;
-        } else {
-            self.text_range.end = result.text_range.start;
-        }
+        self.text_range.start = result.text_range.end;
+        debug_assert!(!self.glyph_range.is_empty());
         result
     }
 
-    fn first_byte_of_glyph(&self, index: usize, direction: Direction) -> usize {
-        self.get(index + usize::from(direction.is_reverse()))
-            .map_or(self.text_range.start, |g| {
-                g.cluster + usize::from(direction.is_reverse())
-            })
+    fn split_off_logical_end(&mut self, pivot: usize) -> Self {
+        let result = self.subslice(pivot..self.len());
+        self.glyph_range.end = self.glyph_range.start + pivot;
+        self.text_range.end = result.text_range.start;
+        debug_assert!(!self.glyph_range.is_empty());
+        result
     }
 
-    fn iter_indices_half_exclusive(
+    fn try_concat_with_reshaped_end(
         &self,
         pivot: usize,
-        forward: bool,
-    ) -> impl Iterator<Item = usize> {
-        let mut i;
-        let end;
-        let step: isize;
-        if !forward {
-            end = 0;
-            i = pivot.saturating_sub(1);
-            step = -1;
-        } else {
-            end = self.len() - 1;
-            i = (pivot + 1).min(end);
-            step = 1;
-        };
-
-        std::iter::from_fn(move || {
-            if i == end {
-                None
-            } else {
-                let value = i;
-                i = i.wrapping_add_signed(step);
-                Some(value)
-            }
-        })
-    }
-
-    fn try_concat_with_reshaped_half(
-        &self,
-        pivot: usize,
-        direction: Direction,
-        forward: bool,
         shaper: &mut RunShaper,
         font_iterator: FontMatchIterator<'_>,
         lctx: &mut LayoutContext,
     ) -> Result<Option<Vec<Self>>, ShapingError> {
-        match direction.is_reverse() ^ forward {
-            false => {
-                let mut other =
-                    GlyphStringSegmentSink(vec![self.subslice(0..pivot + 1, direction)]);
-                shaper.shape(&mut other, font_iterator, lctx)?;
-                if other.0[1..]
-                    .first()
-                    .and_then(|x| x.first())
-                    .is_some_and(|first| first.unsafe_to_concat())
-                {
-                    return Ok(None);
-                }
-
-                Ok(Some(other.0))
-            }
-            true => {
-                let mut other = GlyphStringSegmentSink(Vec::new());
-                shaper.shape(&mut other, font_iterator, lctx)?;
-                if other
-                    .0
-                    .last()
-                    .and_then(|x| x.last())
-                    .is_some_and(|last| last.unsafe_to_concat())
-                {
-                    return Ok(None);
-                }
-
-                other.0.push(self.subslice(pivot..self.len(), direction));
-                Ok(Some(other.0))
-            }
+        let mut other = GlyphStringSegmentSink(vec![self.subslice(0..pivot + 1)]);
+        shaper.shape(&mut other, font_iterator, lctx)?;
+        if other.0[1..]
+            .first()
+            .and_then(|x| x.first())
+            .is_some_and(|first| first.unsafe_to_concat())
+        {
+            return Ok(None);
         }
+
+        Ok(Some(other.0))
     }
 
     fn break_until(
@@ -211,33 +158,23 @@ impl GlyphStringSegment {
     ) -> Result<Vec<Self>, ShapingError> {
         // If the break is within a glyph (like a long ligature), we must
         // use the slow reshaping path.
-        let can_reuse_split_glyph = self.first_byte_of_glyph(glyph_index, direction) == break_index;
+        let can_reuse_split_glyph = self[glyph_index].cluster == break_index;
         if !self[glyph_index].unsafe_to_break() && can_reuse_split_glyph {
             // Easy case, we can just split the glyph string right here
-            if !direction.is_reverse() {
-                return Ok(self.subslice_into_vec(0..glyph_index, direction));
-            } else {
-                return Ok(self.subslice_into_vec(glyph_index + 1..self.len(), direction));
-            }
-        } else if self.len() > 1 {
+            return Ok(self.subslice_into_vec(0..glyph_index));
+        } else if glyph_index > 1 {
             // The hard case, we have to find the closest glyph on the left which
             // has the UNSAFE_TO_CONCAT flag unset, then try reshaping after such glyphs
             // until the first glyph of the result also has the UNSAFE_TO_CONCAT flag unset.
-            for i in self.iter_indices_half_exclusive(glyph_index, direction.is_reverse()) {
+            for i in (1..glyph_index).rev() {
                 if !self[i].unsafe_to_concat() {
-                    let reshape_cluster = self[i + usize::from(!direction.is_reverse())].cluster
-                        + usize::from(direction.is_reverse());
+                    let reshape_cluster = self[i + 1].cluster;
                     let reshape_range = reshape_cluster..break_index;
 
                     shaper.set_buffer_content(&text, reshape_range, direction);
-                    if let Some(result) = self.try_concat_with_reshaped_half(
-                        i,
-                        direction,
-                        false,
-                        shaper,
-                        font_iterator.clone(),
-                        lctx,
-                    )? {
+                    if let Some(result) =
+                        self.try_concat_with_reshaped_end(i, shaper, font_iterator.clone(), lctx)?
+                    {
                         return Ok(result);
                     }
                 }
@@ -252,7 +189,29 @@ impl GlyphStringSegment {
         Ok(result.0)
     }
 
-    // Analogous to `break_after` but returns the part logically after `break_index` (inclusive).
+    fn try_concat_with_reshaped_start(
+        &self,
+        pivot: usize,
+        shaper: &mut RunShaper,
+        font_iterator: FontMatchIterator<'_>,
+        lctx: &mut LayoutContext,
+    ) -> Result<Option<Vec<Self>>, ShapingError> {
+        let mut other = GlyphStringSegmentSink(Vec::new());
+        shaper.shape(&mut other, font_iterator, lctx)?;
+        if other
+            .0
+            .last()
+            .and_then(|x| x.last())
+            .is_some_and(|last| last.unsafe_to_concat())
+        {
+            return Ok(None);
+        }
+
+        other.0.push(self.subslice(pivot..self.len()));
+        Ok(Some(other.0))
+    }
+
+    // Analogous to `break_until` but returns the part logically after `break_index` (inclusive).
     fn break_after(
         &self,
         text: Rc<str>,
@@ -263,29 +222,19 @@ impl GlyphStringSegment {
         lctx: &mut LayoutContext,
         direction: Direction,
     ) -> Result<Vec<GlyphStringSegment>, ShapingError> {
-        let can_reuse_split_glyph = self.first_byte_of_glyph(glyph_index, direction) == break_index;
+        let can_reuse_split_glyph = self[glyph_index].cluster == break_index;
         if !self[glyph_index].unsafe_to_break() && can_reuse_split_glyph {
-            if !direction.is_reverse() {
-                return Ok(self.subslice_into_vec(glyph_index..self.len(), direction));
-            } else {
-                return Ok(self.subslice_into_vec(0..glyph_index + 1, direction));
-            }
-        } else {
-            for i in self.iter_indices_half_exclusive(glyph_index, !direction.is_reverse()) {
+            return Ok(self.subslice_into_vec(glyph_index..self.len()));
+        } else if glyph_index < self.len() - 2 {
+            for i in glyph_index + 1..self.len() - 1 {
                 if !self[i].unsafe_to_concat() {
-                    let reshape_cluster = self[i + usize::from(direction.is_reverse())].cluster
-                        + usize::from(direction.is_reverse());
+                    let reshape_cluster = self[i].cluster;
                     let reshape_range = break_index..reshape_cluster;
 
                     shaper.set_buffer_content(text.as_ref(), reshape_range, direction);
-                    if let Some(result) = self.try_concat_with_reshaped_half(
-                        i,
-                        direction,
-                        true,
-                        shaper,
-                        font_iterator.clone(),
-                        lctx,
-                    )? {
+                    if let Some(result) =
+                        self.try_concat_with_reshaped_start(i, shaper, font_iterator.clone(), lctx)?
+                    {
                         return Ok(result);
                     }
                 }
@@ -300,30 +249,12 @@ impl GlyphStringSegment {
         Ok(result.0)
     }
 
-    fn glyph_at_utf8_index(&self, index: usize, direction: Direction) -> Option<usize> {
+    fn glyph_at_utf8_index(&self, index: usize) -> Option<usize> {
         if !self.text_range.contains(&index) {
             return None;
         }
 
-        Some(if !direction.is_reverse() {
-            self.iter()
-                .enumerate()
-                .find_map(|(i, g)| match g.cluster.cmp(&index) {
-                    std::cmp::Ordering::Equal => Some(i),
-                    std::cmp::Ordering::Greater => i.checked_sub(1),
-                    std::cmp::Ordering::Less => None,
-                })
-                .unwrap_or(self.len() - 1)
-        } else {
-            self.iter()
-                .enumerate()
-                .find_map(|(i, g)| match g.cluster.cmp(&index) {
-                    std::cmp::Ordering::Equal => Some(i),
-                    std::cmp::Ordering::Less => i.checked_sub(1),
-                    std::cmp::Ordering::Greater => None,
-                })
-                .unwrap_or(self.len() - 1)
-        })
+        Some(self.iter().position(|g| g.cluster >= index).unwrap())
     }
 }
 
@@ -357,23 +288,23 @@ impl GlyphString {
         }
     }
 
-    pub fn iter_fonts_visual(&self) -> impl DoubleEndedIterator<Item = &Font> {
+    pub fn iter_fonts_logical(&self) -> impl DoubleEndedIterator<Item = &Font> {
         self.segments.iter().map(|s| &s.font)
     }
 
     pub fn iter_glyphs_visual(&self) -> impl DoubleEndedIterator<Item = (&Font, &Glyph)> {
-        self.segments
-            .iter()
-            .flat_map(|s| s.iter().map(|g| (&s.font, g)))
-    }
-
-    pub fn iter_glyphs_logical(&self) -> impl DoubleEndedIterator<Item = (&Font, &Glyph)> {
         RevIf::new(
             self.segments
                 .iter()
                 .flat_map(|s| s.iter().map(|g| (&s.font, g))),
             self.direction.is_reverse(),
         )
+    }
+
+    pub fn iter_glyphs_logical(&self) -> impl DoubleEndedIterator<Item = (&Font, &Glyph)> {
+        self.segments
+            .iter()
+            .flat_map(|s| s.iter().map(|g| (&s.font, g)))
     }
 
     pub fn is_empty(&self) -> bool {
@@ -388,51 +319,79 @@ impl GlyphString {
         self.direction
     }
 
-    pub(super) fn split_off_visual_start(&mut self, end_utf8_index: usize) -> Option<Self> {
-        let target_utf8_index = match self.direction.is_reverse() {
-            false => end_utf8_index.checked_sub(1)?,
-            true => end_utf8_index,
-        };
-
+    fn split_off_logical_half(&mut self, utf8_pivot: usize, forward: bool) -> Option<Self> {
         let mut i = 0;
-        while i < self.segments.len() {
-            let segment = &mut self.segments[i];
-            // Make sure we're not already past the passed index which can happen
-            // due to whitespace collapsing during line-breaking.
-            if !self.direction.is_reverse() {
-                if segment.text_range.start >= end_utf8_index {
-                    break;
-                }
-            } else if segment.text_range.end < end_utf8_index {
-                // TODO: Is this case right?
+        for segment in self.segments.iter_mut() {
+            if segment.text_range.start >= utf8_pivot {
                 break;
             }
 
-            if let Some(last_glyph_index) =
-                segment.glyph_at_utf8_index(target_utf8_index, self.direction)
-            {
-                let last = segment.split_off_visual_start(last_glyph_index + 1, self.direction);
-                let result = self.segments.drain(..i);
-
-                return Some(Self {
-                    text: self.text.clone(),
-                    segments: result.chain(std::iter::once(last)).collect(),
-                    direction: self.direction,
-                });
+            if segment.text_range.end <= utf8_pivot {
+                i += 1;
+                continue;
             }
 
-            i += 1;
+            let Some(pivot) = segment.iter().position(|g| g.cluster >= utf8_pivot) else {
+                i += 1;
+                continue;
+            };
+            debug_assert!(pivot > 0);
+
+            // TODO: Replace the below `.chain()` calls with `std::iter::chain` (needs MSRV >= 1.91)
+            if forward {
+                let last = segment.split_off_logical_start(pivot);
+                return Some(Self {
+                    text: self.text.clone(),
+                    segments: self
+                        .segments
+                        .drain(..i)
+                        .chain(std::iter::once(last))
+                        .collect(),
+                    direction: self.direction,
+                });
+            } else {
+                let first = segment.split_off_logical_end(pivot);
+                return Some(Self {
+                    text: self.text.clone(),
+                    segments: std::iter::once(first)
+                        .chain(self.segments.drain(i + 1..))
+                        .collect(),
+                    direction: self.direction,
+                });
+            };
         }
 
-        if i > 0 {
-            Some(GlyphString {
-                text: self.text.clone(),
-                segments: self.segments.drain(..i).collect(),
-                direction: self.direction,
-            })
+        let segments = if forward {
+            if i == 0 {
+                return None;
+            }
+
+            self.segments.drain(..i).collect()
         } else {
-            None
-        }
+            if i == self.segments.len() {
+                return None;
+            }
+
+            self.segments.drain(i..).collect()
+        };
+
+        Some(GlyphString {
+            text: self.text.clone(),
+            segments,
+            direction: self.direction,
+        })
+    }
+
+    pub(super) fn split_off_logical_start(&mut self, end_utf8_index: usize) -> Option<Self> {
+        self.split_off_logical_half(end_utf8_index, true)
+    }
+
+    pub(super) fn split_off_logical_end(&mut self, start_utf8_index: usize) -> Option<Self> {
+        self.split_off_logical_half(start_utf8_index, false)
+    }
+
+    pub(super) fn split_off_visual_start(&mut self, end_utf8_index: usize) -> Option<Self> {
+        self.split_off_logical_half(end_utf8_index, !self.direction.is_reverse())
     }
 
     // NOTE: Unlike [`Glyph::cluster`] the break range indices here always point to the first byte
@@ -449,35 +408,15 @@ impl GlyphString {
 
         let left_segments;
         let mut current_x = I26Dot6::ZERO;
-        let mut it = RevIf::new(
-            self.segments.iter().enumerate(),
-            self.direction.is_reverse(),
-        );
+        let mut it = self.segments.iter().enumerate();
         let mut next = it.next();
-        let slice_segments = |pivot: usize, after: bool| {
-            if !self.direction.is_reverse() ^ after {
-                &self.segments[..pivot]
-            } else {
-                &self.segments[pivot + 1..]
-            }
-        };
-        let append =
-            |list: &[GlyphStringSegment], other: &mut Vec<GlyphStringSegment>, invert: bool| {
-                if !self.direction.is_reverse() ^ invert {
-                    other.splice(0..0, list.iter().cloned());
-                } else {
-                    other.extend_from_slice(list);
-                }
-            };
 
         loop {
             let Some((i, segment)) = next else {
                 return Ok(None);
             };
 
-            if let Some(left_candidate_glyph) =
-                segment.glyph_at_utf8_index(break_range.start, self.direction)
-            {
+            if let Some(left_candidate_glyph) = segment.glyph_at_utf8_index(break_range.start) {
                 let mut left_candidate = segment.break_until(
                     self.text.clone(),
                     left_candidate_glyph,
@@ -495,7 +434,7 @@ impl GlyphString {
                     .fold(current_x, I26Dot6::add)
                     <= max_width
                 {
-                    append(slice_segments(i, false), &mut left_candidate, false);
+                    left_candidate.splice(0..0, self.segments[..i].iter().cloned());
                     left_segments = left_candidate;
                     break;
                 } else {
@@ -517,9 +456,7 @@ impl GlyphString {
             direction: self.direction,
         };
         while let Some((i, segment)) = next {
-            if let Some(right_candidate_glyph) =
-                segment.glyph_at_utf8_index(break_range.end, self.direction)
-            {
+            if let Some(right_candidate_glyph) = segment.glyph_at_utf8_index(break_range.end) {
                 let mut right_segments = segment.break_after(
                     self.text.clone(),
                     right_candidate_glyph,
@@ -530,7 +467,7 @@ impl GlyphString {
                     self.direction,
                 )?;
 
-                append(slice_segments(i, true), &mut right_segments, true);
+                right_segments.extend_from_slice(&self.segments[i + 1..]);
 
                 return Ok(Some((
                     left,
@@ -546,5 +483,45 @@ impl GlyphString {
         }
 
         Ok(Some((left, Self::new(self.text.clone(), self.direction))))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::rc::Rc;
+
+    use util::math::I26Dot6;
+
+    use super::GlyphString;
+    use crate::text::{Direction, Face, Glyph};
+
+    #[test]
+    fn split_off_in_glyph() {
+        let original = {
+            let font = Face::tofu().with_size(I26Dot6::new(16), 72).unwrap();
+            let mut result = GlyphString::new(Rc::from("abcde"), Direction::Ltr);
+            result.segments.extend([
+                super::GlyphStringSegment {
+                    storage: Rc::from([Glyph::test_new(1, 0), Glyph::test_new(2, 1)]),
+                    glyph_range: 0..2,
+                    text_range: 0..3,
+                    font: font.clone(),
+                },
+                super::GlyphStringSegment {
+                    storage: Rc::from([Glyph::test_new(3, 3)]),
+                    glyph_range: 0..2,
+                    text_range: 3..5,
+                    font,
+                },
+            ]);
+            result
+        };
+
+        let start = original.clone().split_off_logical_start(2).unwrap();
+        let end = original.clone().split_off_logical_end(2).unwrap();
+        assert_eq!(start.segments.len(), 1);
+        assert_eq!(start.segments[0].text_range, 0..3);
+        assert_eq!(end.segments.len(), 1);
+        assert_eq!(end.segments[0].text_range, 3..5);
     }
 }

--- a/src/layout/inline/glyph_string.rs
+++ b/src/layout/inline/glyph_string.rs
@@ -7,10 +7,10 @@ use std::{
 
 use util::{math::I26Dot6, rev_if::RevIf};
 
-use super::FontFeatureEvent;
+use super::RunShaper;
 use crate::{
     layout::LayoutContext,
-    text::{Direction, Font, FontMatchIterator, Glyph, ShapingBuffer, ShapingError, ShapingSink},
+    text::{Direction, Font, FontMatchIterator, Glyph, ShapingError, ShapingSink},
 };
 
 #[derive(Clone)]
@@ -194,9 +194,7 @@ impl GlyphStringSegment {
         text: Rc<str>,
         glyph_index: usize,
         break_index: usize,
-        buffer: &mut ShapingBuffer,
-        font_feature_events: &[FontFeatureEvent],
-        grapheme_cluster_boundaries: &[usize],
+        shaper: &mut RunShaper,
         font_iterator: FontMatchIterator<'_>,
         lctx: &mut LayoutContext,
         direction: Direction,
@@ -221,17 +219,9 @@ impl GlyphStringSegment {
                         + usize::from(direction.is_reverse());
                     let reshape_range = reshape_cluster..break_index;
 
-                    buffer.clear();
-                    buffer.set_direction(direction);
-                    super::set_buffer_content_from_range(
-                        buffer,
-                        text.as_ref(),
-                        reshape_range,
-                        font_feature_events,
-                        grapheme_cluster_boundaries,
-                    );
+                    shaper.set_buffer_content(&text, reshape_range, direction);
                     let mut other = GlyphStringSegmentSink::new();
-                    buffer.shape(lctx.log, &mut other, font_iterator.clone(), lctx.fonts)?;
+                    shaper.shape(&mut other, font_iterator.clone(), lctx)?;
 
                     if let Some(result) = self.try_concat_with_half(i, other.0, direction, false) {
                         return Ok(result);
@@ -242,17 +232,9 @@ impl GlyphStringSegment {
 
         // We have to reshape the whole segment, there's no place where we can safely concat.
         let reshape_range = self.text_range.start..break_index;
-        buffer.clear();
-        buffer.set_direction(direction);
-        super::set_buffer_content_from_range(
-            buffer,
-            text.as_ref(),
-            reshape_range,
-            font_feature_events,
-            grapheme_cluster_boundaries,
-        );
+        shaper.set_buffer_content(text.as_ref(), reshape_range, direction);
         let mut result = GlyphStringSegmentSink::new();
-        buffer.shape(lctx.log, &mut result, font_iterator, lctx.fonts)?;
+        shaper.shape(&mut result, font_iterator, lctx)?;
         Ok(result.0)
     }
 
@@ -262,9 +244,7 @@ impl GlyphStringSegment {
         text: Rc<str>,
         glyph_index: usize,
         break_index: usize,
-        buffer: &mut ShapingBuffer,
-        font_feature_events: &[FontFeatureEvent],
-        grapheme_cluster_boundaries: &[usize],
+        shaper: &mut RunShaper,
         font_iterator: FontMatchIterator<'_>,
         lctx: &mut LayoutContext,
         direction: Direction,
@@ -283,17 +263,9 @@ impl GlyphStringSegment {
                         + usize::from(direction.is_reverse());
                     let reshape_range = break_index..reshape_cluster;
 
-                    buffer.clear();
-                    buffer.set_direction(direction);
-                    super::set_buffer_content_from_range(
-                        buffer,
-                        text.as_ref(),
-                        reshape_range,
-                        font_feature_events,
-                        grapheme_cluster_boundaries,
-                    );
+                    shaper.set_buffer_content(text.as_ref(), reshape_range, direction);
                     let mut other = GlyphStringSegmentSink::new();
-                    buffer.shape(lctx.log, &mut other, font_iterator.clone(), lctx.fonts)?;
+                    shaper.shape(&mut other, font_iterator.clone(), lctx)?;
 
                     if let Some(result) = self.try_concat_with_half(i, other.0, direction, true) {
                         return Ok(result);
@@ -304,17 +276,9 @@ impl GlyphStringSegment {
 
         // We have to reshape the whole segment, there's no place where we can safely concat.
         let reshape_range = break_index..self.text_range.end;
-        buffer.clear();
-        buffer.set_direction(direction);
-        super::set_buffer_content_from_range(
-            buffer,
-            text.as_ref(),
-            reshape_range,
-            font_feature_events,
-            grapheme_cluster_boundaries,
-        );
+        shaper.set_buffer_content(text.as_ref(), reshape_range, direction);
         let mut result = GlyphStringSegmentSink::new();
-        buffer.shape(lctx.log, &mut result, font_iterator, lctx.fonts)?;
+        shaper.shape(&mut result, font_iterator, lctx)?;
         Ok(result.0)
     }
 
@@ -481,9 +445,7 @@ impl GlyphString {
         &self,
         break_range: Range<usize>,
         max_width: I26Dot6,
-        buffer: &mut ShapingBuffer,
-        font_feature_events: &[FontFeatureEvent],
-        grapheme_cluster_boundaries: &[usize],
+        shaper: &mut RunShaper,
         font_iter: FontMatchIterator<'_>,
         lctx: &mut LayoutContext,
     ) -> Result<Option<(Self, Self)>, ShapingError> {
@@ -522,9 +484,7 @@ impl GlyphString {
                     self.text.clone(),
                     left_candidate_glyph,
                     break_range.start,
-                    buffer,
-                    font_feature_events,
-                    grapheme_cluster_boundaries,
+                    shaper,
                     font_iter.clone(),
                     lctx,
                     self.direction,
@@ -566,9 +526,7 @@ impl GlyphString {
                     self.text.clone(),
                     right_candidate_glyph,
                     break_range.end,
-                    buffer,
-                    font_feature_events,
-                    grapheme_cluster_boundaries,
+                    shaper,
                     font_iter,
                     lctx,
                     self.direction,

--- a/src/layout/inline/glyph_string.rs
+++ b/src/layout/inline/glyph_string.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::LinkedList,
     fmt::Debug,
     ops::{Add as _, Deref, Range},
     rc::Rc,
@@ -18,7 +17,7 @@ pub struct GlyphString {
     /// Always refers to the original string that contains the whole context
     /// of this string.
     text: Rc<str>,
-    segments: LinkedList<GlyphStringSegment>,
+    segments: Vec<GlyphStringSegment>,
     direction: Direction,
 }
 
@@ -103,12 +102,12 @@ impl GlyphStringSegment {
     // [`Self::subslice`] does not allow creating an empty subslice so that "no empty segments"
     // can be an invariant upheld by [`GlyphString`].
     // This function allows for empty subslices but returns them as an empty [`LinkedList`].
-    fn subslice_into_list(&self, range: Range<usize>, direction: Direction) -> LinkedList<Self> {
+    fn subslice_into_vec(&self, range: Range<usize>, direction: Direction) -> Vec<Self> {
         if range.start == range.end {
-            return LinkedList::new();
+            return Vec::new();
         }
 
-        LinkedList::from([self.subslice(range, direction)])
+        Vec::from([self.subslice(range, direction)])
     }
 
     fn split_off_visual_start(&mut self, pivot: usize, direction: Direction) -> Self {
@@ -158,34 +157,45 @@ impl GlyphStringSegment {
         })
     }
 
-    fn try_concat_with_half(
+    fn try_concat_with_reshaped_half(
         &self,
         pivot: usize,
-        mut other: LinkedList<Self>,
         direction: Direction,
         forward: bool,
-    ) -> Option<LinkedList<Self>> {
+        shaper: &mut RunShaper,
+        font_iterator: FontMatchIterator<'_>,
+        lctx: &mut LayoutContext,
+    ) -> Result<Option<Vec<Self>>, ShapingError> {
         match direction.is_reverse() ^ forward {
-            false
-                if other
-                    .iter()
-                    .next()
+            false => {
+                let mut other =
+                    GlyphStringSegmentSink(vec![self.subslice(0..pivot + 1, direction)]);
+                shaper.shape(&mut other, font_iterator, lctx)?;
+                if other.0[1..]
+                    .first()
                     .and_then(|x| x.first())
-                    .is_none_or(|first| !first.unsafe_to_concat()) =>
-            {
-                other.push_front(self.subslice(0..pivot + 1, direction));
-                Some(other)
+                    .is_some_and(|first| first.unsafe_to_concat())
+                {
+                    return Ok(None);
+                }
+
+                Ok(Some(other.0))
             }
-            true if other
-                .iter()
-                .next_back()
-                .and_then(|x| x.last())
-                .is_none_or(|last| !last.unsafe_to_concat()) =>
-            {
-                other.push_back(self.subslice(pivot..self.len(), direction));
-                Some(other)
+            true => {
+                let mut other = GlyphStringSegmentSink(Vec::new());
+                shaper.shape(&mut other, font_iterator, lctx)?;
+                if other
+                    .0
+                    .last()
+                    .and_then(|x| x.last())
+                    .is_some_and(|last| last.unsafe_to_concat())
+                {
+                    return Ok(None);
+                }
+
+                other.0.push(self.subslice(pivot..self.len(), direction));
+                Ok(Some(other.0))
             }
-            _ => None,
         }
     }
 
@@ -198,16 +208,16 @@ impl GlyphStringSegment {
         font_iterator: FontMatchIterator<'_>,
         lctx: &mut LayoutContext,
         direction: Direction,
-    ) -> Result<LinkedList<Self>, ShapingError> {
+    ) -> Result<Vec<Self>, ShapingError> {
         // If the break is within a glyph (like a long ligature), we must
         // use the slow reshaping path.
         let can_reuse_split_glyph = self.first_byte_of_glyph(glyph_index, direction) == break_index;
         if !self[glyph_index].unsafe_to_break() && can_reuse_split_glyph {
             // Easy case, we can just split the glyph string right here
             if !direction.is_reverse() {
-                return Ok(self.subslice_into_list(0..glyph_index, direction));
+                return Ok(self.subslice_into_vec(0..glyph_index, direction));
             } else {
-                return Ok(self.subslice_into_list(glyph_index + 1..self.len(), direction));
+                return Ok(self.subslice_into_vec(glyph_index + 1..self.len(), direction));
             }
         } else if self.len() > 1 {
             // The hard case, we have to find the closest glyph on the left which
@@ -220,10 +230,14 @@ impl GlyphStringSegment {
                     let reshape_range = reshape_cluster..break_index;
 
                     shaper.set_buffer_content(&text, reshape_range, direction);
-                    let mut other = GlyphStringSegmentSink::new();
-                    shaper.shape(&mut other, font_iterator.clone(), lctx)?;
-
-                    if let Some(result) = self.try_concat_with_half(i, other.0, direction, false) {
+                    if let Some(result) = self.try_concat_with_reshaped_half(
+                        i,
+                        direction,
+                        false,
+                        shaper,
+                        font_iterator.clone(),
+                        lctx,
+                    )? {
                         return Ok(result);
                     }
                 }
@@ -233,7 +247,7 @@ impl GlyphStringSegment {
         // We have to reshape the whole segment, there's no place where we can safely concat.
         let reshape_range = self.text_range.start..break_index;
         shaper.set_buffer_content(text.as_ref(), reshape_range, direction);
-        let mut result = GlyphStringSegmentSink::new();
+        let mut result = GlyphStringSegmentSink(Vec::new());
         shaper.shape(&mut result, font_iterator, lctx)?;
         Ok(result.0)
     }
@@ -248,13 +262,13 @@ impl GlyphStringSegment {
         font_iterator: FontMatchIterator<'_>,
         lctx: &mut LayoutContext,
         direction: Direction,
-    ) -> Result<LinkedList<GlyphStringSegment>, ShapingError> {
+    ) -> Result<Vec<GlyphStringSegment>, ShapingError> {
         let can_reuse_split_glyph = self.first_byte_of_glyph(glyph_index, direction) == break_index;
         if !self[glyph_index].unsafe_to_break() && can_reuse_split_glyph {
             if !direction.is_reverse() {
-                return Ok(self.subslice_into_list(glyph_index..self.len(), direction));
+                return Ok(self.subslice_into_vec(glyph_index..self.len(), direction));
             } else {
-                return Ok(self.subslice_into_list(0..glyph_index + 1, direction));
+                return Ok(self.subslice_into_vec(0..glyph_index + 1, direction));
             }
         } else {
             for i in self.iter_indices_half_exclusive(glyph_index, !direction.is_reverse()) {
@@ -264,10 +278,14 @@ impl GlyphStringSegment {
                     let reshape_range = break_index..reshape_cluster;
 
                     shaper.set_buffer_content(text.as_ref(), reshape_range, direction);
-                    let mut other = GlyphStringSegmentSink::new();
-                    shaper.shape(&mut other, font_iterator.clone(), lctx)?;
-
-                    if let Some(result) = self.try_concat_with_half(i, other.0, direction, true) {
+                    if let Some(result) = self.try_concat_with_reshaped_half(
+                        i,
+                        direction,
+                        true,
+                        shaper,
+                        font_iterator.clone(),
+                        lctx,
+                    )? {
                         return Ok(result);
                     }
                 }
@@ -277,7 +295,7 @@ impl GlyphStringSegment {
         // We have to reshape the whole segment, there's no place where we can safely concat.
         let reshape_range = break_index..self.text_range.end;
         shaper.set_buffer_content(text.as_ref(), reshape_range, direction);
-        let mut result = GlyphStringSegmentSink::new();
+        let mut result = GlyphStringSegmentSink(Vec::new());
         shaper.shape(&mut result, font_iterator, lctx)?;
         Ok(result.0)
     }
@@ -309,23 +327,11 @@ impl GlyphStringSegment {
     }
 }
 
-impl GlyphString {
-    pub fn new(text: Rc<str>, direction: Direction) -> Self {
-        GlyphString::from_array(text, [], direction)
-    }
-}
-
-struct GlyphStringSegmentSink(LinkedList<GlyphStringSegment>);
-
-impl GlyphStringSegmentSink {
-    fn new() -> Self {
-        Self(LinkedList::new())
-    }
-}
+struct GlyphStringSegmentSink(Vec<GlyphStringSegment>);
 
 impl ShapingSink for GlyphStringSegmentSink {
     fn append(&mut self, text_range: Range<usize>, font: &Font, glyphs: &[Glyph]) {
-        self.0.push_back(GlyphStringSegment {
+        self.0.push(GlyphStringSegment {
             storage: glyphs.into(),
             glyph_range: 0..glyphs.len(),
             text_range,
@@ -342,18 +348,11 @@ impl ShapingSink for GlyphString {
     }
 }
 
-// TODO: linked_list_cursors feature would improve some of this code significantly
 impl GlyphString {
-    fn from_array<const N: usize>(
-        text: Rc<str>,
-        segments: [GlyphStringSegment; N],
-        direction: Direction,
-    ) -> GlyphString {
-        GlyphString {
+    pub fn new(text: Rc<str>, direction: Direction) -> Self {
+        Self {
             text,
-            segments: LinkedList::from_iter(
-                segments.into_iter().filter(|segment| !segment.is_empty()),
-            ),
+            segments: Vec::new(),
             direction,
         }
     }
@@ -390,13 +389,14 @@ impl GlyphString {
     }
 
     pub(super) fn split_off_visual_start(&mut self, end_utf8_index: usize) -> Option<Self> {
-        let mut result = LinkedList::new();
         let target_utf8_index = match self.direction.is_reverse() {
             false => end_utf8_index.checked_sub(1)?,
             true => end_utf8_index,
         };
 
-        while let Some(segment) = self.segments.front() {
+        let mut i = 0;
+        while i < self.segments.len() {
+            let segment = &mut self.segments[i];
             // Make sure we're not already past the passed index which can happen
             // due to whitespace collapsing during line-breaking.
             if !self.direction.is_reverse() {
@@ -407,31 +407,27 @@ impl GlyphString {
                 // TODO: Is this case right?
                 break;
             }
-            let mut segment = self.segments.pop_front().unwrap();
 
-            match segment.glyph_at_utf8_index(target_utf8_index, self.direction) {
-                Some(last_glyph_index) => {
-                    result.push_back(
-                        segment.split_off_visual_start(last_glyph_index + 1, self.direction),
-                    );
-                    if !segment.is_empty() {
-                        self.segments.push_front(segment);
-                    }
+            if let Some(last_glyph_index) =
+                segment.glyph_at_utf8_index(target_utf8_index, self.direction)
+            {
+                let last = segment.split_off_visual_start(last_glyph_index + 1, self.direction);
+                let result = self.segments.drain(..i);
 
-                    return Some(Self {
-                        text: self.text.clone(),
-                        segments: result,
-                        direction: self.direction,
-                    });
-                }
-                None => result.push_back(segment),
+                return Some(Self {
+                    text: self.text.clone(),
+                    segments: result.chain(std::iter::once(last)).collect(),
+                    direction: self.direction,
+                });
             }
+
+            i += 1;
         }
 
-        if !result.is_empty() {
+        if i > 0 {
             Some(GlyphString {
                 text: self.text.clone(),
-                segments: result,
+                segments: self.segments.drain(..i).collect(),
                 direction: self.direction,
             })
         } else {
@@ -451,29 +447,31 @@ impl GlyphString {
     ) -> Result<Option<(Self, Self)>, ShapingError> {
         assert!(!self.is_empty());
 
-        let mut left_segments = LinkedList::new();
+        let left_segments;
         let mut current_x = I26Dot6::ZERO;
-        let mut it = RevIf::new(self.segments.iter(), self.direction.is_reverse());
+        let mut it = RevIf::new(
+            self.segments.iter().enumerate(),
+            self.direction.is_reverse(),
+        );
         let mut next = it.next();
-        let push = |list: &mut LinkedList<GlyphStringSegment>, segment: GlyphStringSegment| {
-            if !self.direction.is_reverse() {
-                list.push_back(segment);
+        let slice_segments = |pivot: usize, after: bool| {
+            if !self.direction.is_reverse() ^ after {
+                &self.segments[..pivot]
             } else {
-                list.push_front(segment);
+                &self.segments[pivot + 1..]
             }
         };
-        let append = |list: &mut LinkedList<GlyphStringSegment>,
-                      other: &mut LinkedList<GlyphStringSegment>| {
-            if !self.direction.is_reverse() {
-                list.append(other);
-            } else {
-                other.append(list);
-                std::mem::swap(list, other);
-            }
-        };
+        let append =
+            |list: &[GlyphStringSegment], other: &mut Vec<GlyphStringSegment>, invert: bool| {
+                if !self.direction.is_reverse() ^ invert {
+                    other.splice(0..0, list.iter().cloned());
+                } else {
+                    other.extend_from_slice(list);
+                }
+            };
 
         loop {
-            let Some(segment) = next else {
+            let Some((i, segment)) = next else {
                 return Ok(None);
             };
 
@@ -497,7 +495,8 @@ impl GlyphString {
                     .fold(current_x, I26Dot6::add)
                     <= max_width
                 {
-                    append(&mut left_segments, &mut left_candidate);
+                    append(slice_segments(i, false), &mut left_candidate, false);
+                    left_segments = left_candidate;
                     break;
                 } else {
                     // This wasn't a valid break because the width ended up being too large.
@@ -508,7 +507,6 @@ impl GlyphString {
             for glyph in segment {
                 current_x += glyph.x_advance;
             }
-            push(&mut left_segments, segment.clone());
 
             next = it.next();
         }
@@ -518,7 +516,7 @@ impl GlyphString {
             segments: left_segments,
             direction: self.direction,
         };
-        while let Some(segment) = next {
+        while let Some((i, segment)) = next {
             if let Some(right_candidate_glyph) =
                 segment.glyph_at_utf8_index(break_range.end, self.direction)
             {
@@ -532,12 +530,7 @@ impl GlyphString {
                     self.direction,
                 )?;
 
-                append(
-                    &mut right_segments,
-                    // NOTE: For this to be correct we need to go back to iterating in visual order
-                    //       so `RevIf::into_inner` first.
-                    &mut it.into_inner().cloned().collect::<LinkedList<_>>(),
-                );
+                append(slice_segments(i, true), &mut right_segments, true);
 
                 return Ok(Some((
                     left,
@@ -552,9 +545,6 @@ impl GlyphString {
             next = it.next();
         }
 
-        Ok(Some((
-            left,
-            Self::from_array(self.text.clone(), [], self.direction),
-        )))
+        Ok(Some((left, Self::new(self.text.clone(), self.direction))))
     }
 }

--- a/src/text.rs
+++ b/src/text.rs
@@ -135,6 +135,19 @@ impl Glyph {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn test_new(index: hb_codepoint_t, cluster: usize) -> Self {
+        Self {
+            index,
+            cluster,
+            x_advance: I26Dot6::ZERO,
+            y_advance: I26Dot6::ZERO,
+            x_offset: I26Dot6::ZERO,
+            y_offset: I26Dot6::ZERO,
+            flags: 0,
+        }
+    }
+
     pub fn unsafe_to_break(&self) -> bool {
         (self.flags & HB_GLYPH_FLAG_UNSAFE_TO_BREAK) != 0
     }

--- a/src/text.rs
+++ b/src/text.rs
@@ -97,16 +97,6 @@ impl Direction {
     pub const fn is_reverse(self) -> bool {
         matches!(self, Self::Rtl | Self::Btt)
     }
-
-    #[must_use]
-    pub const fn to_horizontal(self) -> Self {
-        match self {
-            Self::Ltr => Self::Ltr,
-            Self::Rtl => Self::Rtl,
-            Self::Ttb => Self::Ltr,
-            Self::Btt => Self::Rtl,
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/text/shape.rs
+++ b/src/text/shape.rs
@@ -37,24 +37,24 @@ impl RawShapingBuffer {
         }
     }
 
-    fn items_mut(&mut self) -> (&mut [hb_glyph_info_t], &mut [hb_glyph_position_t]) {
-        let infos: &mut [hb_glyph_info_t] = unsafe {
+    fn items(&self) -> (&[hb_glyph_info_t], &[hb_glyph_position_t]) {
+        let infos: &[hb_glyph_info_t] = unsafe {
             let mut nglyphs = 0;
             let infos = hb_buffer_get_glyph_infos(self.0, &mut nglyphs);
             if infos.is_null() {
-                &mut []
+                &[]
             } else {
-                std::slice::from_raw_parts_mut(infos as *mut _, nglyphs as usize)
+                std::slice::from_raw_parts(infos as *const _, nglyphs as usize)
             }
         };
 
-        let positions: &mut [hb_glyph_position_t] = unsafe {
+        let positions: &[hb_glyph_position_t] = unsafe {
             let mut nglyphs = 0;
             let infos = hb_buffer_get_glyph_positions(self.0, &mut nglyphs);
             if infos.is_null() {
-                &mut []
+                &[]
             } else {
-                std::slice::from_raw_parts_mut(infos as *mut _, nglyphs as usize)
+                std::slice::from_raw_parts(infos as *const _, nglyphs as usize)
             }
         };
 
@@ -279,19 +279,6 @@ impl Drop for ShapingBuffer {
     }
 }
 
-// Right to left text will have clusters monotonically decreasing instead of increasing,
-// so we need to fixup cluster ranges so we don't crash when slicing with them.
-fn fixup_range(a: usize, b: usize) -> Range<usize> {
-    if a > b {
-        // fixup_range accepts an *exclusive* range where b is excluded and a is included
-        // *regardless* of which is higher, therefore when reversing it we have to make
-        // sure we're taking this into account.
-        b + 1..a + 1
-    } else {
-        a..b
-    }
-}
-
 struct ShapingPass<'p> {
     log: &'p LogContext<'p>,
     buffer: RawShapingBuffer,
@@ -363,8 +350,13 @@ impl ShapingPass<'_> {
                 self.features.len() as u32,
             );
         }
-        let (infos, positions) = self.buffer.items_mut();
 
+        type ItemIter<'a> = std::iter::Zip<
+            std::slice::Iter<'a, hb_glyph_info_t>,
+            std::slice::Iter<'a, hb_glyph_position_t>,
+        >;
+
+        let (infos, positions) = self.buffer.items();
         if infos.is_empty() {
             return Ok(());
         }
@@ -381,15 +373,8 @@ impl ShapingPass<'_> {
         } else {
             cluster_range.end - 1
         };
-        // It is, in general, not possible to compute an excluded end bound for clusters here.
-        // This is because when working with RTL text such an end bound could be `-1`[1].
-        // So we use `usize::MAX` as a sentinel instead and are careful not to
-        // compare clusters with non-equality comparisons.
-        //
-        // [1] Although this placeholder is effectively `-1` :)
-        const END_CLUSTER_EXCLUDED: usize = usize::MAX;
 
-        let make_glyph = |info: &hb_glyph_info_t, position: &hb_glyph_position_t| {
+        let make_glyph = |info: &hb_glyph_info_t, position: &hb_glyph_position_t, it: &ItemIter| {
             let cluster = &self.cluster_map[info.cluster as usize];
             Glyph::from_info_and_position(
                 info,
@@ -397,7 +382,12 @@ impl ShapingPass<'_> {
                 if !is_dir_reverse {
                     cluster.utf8_index
                 } else {
-                    cluster.end_utf8_index() - 1
+                    it.clone()
+                        .find(|x| x.0.cluster != info.cluster)
+                        .map_or_else(
+                            || self.cluster_map[cluster_range.start].utf8_index,
+                            |c| self.cluster_map[c.0.cluster as usize + 1].utf8_index,
+                        )
                 },
                 &font,
             )
@@ -415,6 +405,7 @@ impl ShapingPass<'_> {
         };
 
         let mut glyph_buffer_last = self.glyph_buffer.len();
+        // These ranges are [min, max) if !is_reverse and otherwise they are [max, min].
         let mut successful_ranges = Vec::new();
         let mut it = std::iter::zip(infos, positions);
         while let Some((info, position)) = it.next() {
@@ -440,7 +431,7 @@ impl ShapingPass<'_> {
             // If we don't see a grapheme start at the end of the valid subrange then we
             // will roll back `len` by this value to get rid of the partial ending.
             let mut pending_glyphs = 0;
-            self.glyph_buffer.push(make_glyph(info, position));
+            self.glyph_buffer.push(make_glyph(info, position, &it));
             let cluster_subrange_start = info.cluster as usize;
             let mut cluster_subrange_end = cluster_subrange_start;
             loop {
@@ -448,11 +439,12 @@ impl ShapingPass<'_> {
                     Some((info, position)) => {
                         if is_cluster_initial(info.cluster) {
                             pending_glyphs = 0;
-                            cluster_subrange_end = info.cluster as usize;
+                            cluster_subrange_end =
+                                (info.cluster as usize).wrapping_add(usize::from(is_reverse));
                         }
 
                         if info.codepoint != 0 {
-                            self.glyph_buffer.push(make_glyph(info, position));
+                            self.glyph_buffer.push(make_glyph(info, position, &it));
                             len += 1;
                             pending_glyphs += 1;
                         } else {
@@ -461,7 +453,11 @@ impl ShapingPass<'_> {
                     }
                     None => {
                         pending_glyphs = 0;
-                        cluster_subrange_end = END_CLUSTER_EXCLUDED;
+                        cluster_subrange_end = if !is_reverse {
+                            cluster_range.end
+                        } else {
+                            cluster_range.start
+                        };
                         break;
                     }
                 }
@@ -480,47 +476,70 @@ impl ShapingPass<'_> {
             successful_ranges.push((cluster_subrange_start, cluster_subrange_end, len));
         }
 
-        let text_utf8_start = self.cluster_map[cluster_range.start].utf8_index;
-        let text_utf8_end = self.cluster_map.get(cluster_range.end).map_or_else(
-            || self.cluster_map.last().unwrap().end_utf8_index(),
-            |x| x.utf8_index,
-        );
-        let cluster_range_to_utf8 = |range: Range<usize>| {
-            if !is_reverse {
-                self.cluster_map[range.start].utf8_index..(if range.end == END_CLUSTER_EXCLUDED {
-                    text_utf8_end
-                } else {
-                    self.cluster_map[range.end].utf8_index
-                })
-            } else {
-                (if range.end == END_CLUSTER_EXCLUDED {
-                    text_utf8_start
-                } else {
-                    self.cluster_map[range.end].end_utf8_index()
-                })..self.cluster_map[range.start].end_utf8_index()
+        let mut broken_subrange_start = cluster_range.start;
+        if !is_reverse {
+            let text_utf8_end = self.cluster_map.get(cluster_range.end).map_or_else(
+                || self.cluster_map.last().unwrap().end_utf8_index(),
+                |x| x.utf8_index,
+            );
+            let cluster_range_to_utf8 = |range: Range<usize>| {
+                self.cluster_map[range.start].utf8_index
+                    ..self
+                        .cluster_map
+                        .get(range.end)
+                        .map_or(text_utf8_end, |c| c.utf8_index)
+            };
+            let truncate_to = glyph_buffer_last;
+
+            for (cluster_subrange_start, cluster_subrange_end, len) in successful_ranges {
+                if broken_subrange_start != cluster_subrange_start {
+                    self.retry_shaping(
+                        broken_subrange_start..cluster_subrange_start,
+                        font_iterator.clone(),
+                        force_tofu,
+                    )?;
+                }
+                broken_subrange_start = cluster_subrange_end;
+
+                let text_range =
+                    cluster_range_to_utf8(cluster_subrange_start..cluster_subrange_end);
+                self.output.append(
+                    text_range,
+                    &font.clone(),
+                    &self.glyph_buffer[glyph_buffer_last..glyph_buffer_last + len],
+                );
+                glyph_buffer_last += len;
+            }
+
+            self.glyph_buffer.truncate(truncate_to);
+        } else {
+            let cluster_range_to_utf8 = |start: usize, end: usize| {
+                self.cluster_map[end].utf8_index..self.cluster_map[start].end_utf8_index()
+            };
+
+            for (cluster_subrange_start, cluster_subrange_end, len) in
+                successful_ranges.into_iter().rev()
+            {
+                if broken_subrange_start != cluster_subrange_end {
+                    self.retry_shaping(
+                        broken_subrange_start..cluster_subrange_end,
+                        font_iterator.clone(),
+                        force_tofu,
+                    )?;
+                }
+                broken_subrange_start = cluster_subrange_start + 1;
+
+                let text_range =
+                    cluster_range_to_utf8(cluster_subrange_start, cluster_subrange_end);
+                let glyphs_start = self.glyph_buffer.len() - len;
+                let glyphs = &mut self.glyph_buffer[glyphs_start..];
+                glyphs.reverse();
+                self.output.append(text_range, &font.clone(), glyphs);
+                self.glyph_buffer.truncate(glyphs_start);
             }
         };
 
-        let mut broken_subrange_start = first_cluster;
-        for (cluster_subrange_start, cluster_subrange_end, len) in successful_ranges {
-            if broken_subrange_start != cluster_subrange_start {
-                self.retry_shaping(
-                    fixup_range(broken_subrange_start, cluster_subrange_start),
-                    font_iterator.clone(),
-                    force_tofu,
-                )?;
-            }
-            broken_subrange_start = cluster_subrange_end;
-
-            self.output.append(
-                cluster_range_to_utf8(cluster_subrange_start..cluster_subrange_end),
-                &font.clone(),
-                &self.glyph_buffer[glyph_buffer_last..glyph_buffer_last + len],
-            );
-            glyph_buffer_last += len;
-        }
-
-        if broken_subrange_start != END_CLUSTER_EXCLUDED {
+        if broken_subrange_start != cluster_range.end {
             assert!(!force_tofu, "Tofu font failed to shape any characters");
 
             // This means the font fallback system lied to us and gave us
@@ -528,11 +547,7 @@ impl ShapingPass<'_> {
             let next_force_tofu =
                 broken_subrange_start == start_cluster && font_iterator.did_system_fallback();
 
-            let range = if is_reverse {
-                cluster_range.start..broken_subrange_start + 1
-            } else {
-                broken_subrange_start..cluster_range.end
-            };
+            let range = broken_subrange_start..cluster_range.end;
             self.retry_shaping(range, font_iterator.clone(), next_force_tofu)?
         }
 

--- a/src/vtt/parse.rs
+++ b/src/vtt/parse.rs
@@ -405,6 +405,7 @@ fn collect_webvtt_region_settings<'a>(input: &'a str, region: &mut Region<'a>) {
             continue;
         }
 
+        #[allow(clippy::collapsible_match)] // let's not stuff parsing into match guards
         match name {
             "id" => {
                 region.identifier = value;

--- a/tests/layout/common.rs
+++ b/tests/layout/common.rs
@@ -87,11 +87,17 @@ macro_rules! make_tree {
             content: make_tree!(@build_block_content [$style;] $content_block)
         }
     }};
-    (@build_block_content [$style: expr;] { inline $(.$class: ident)* { $($content: tt)* } }) => {
+    (@build_block_content [$style: expr;] { inline { $($content: tt)* } }) => {
         crate::layout::block::BlockContainerContent::Inline(
-            make_tree!(@build inline $(.$class)*  [$style;]; { $($content)* })
+            make_tree!(@build inline [$style;]; { $($content)* })
         )
     };
+    (@build_block_content [$style: expr;] { inline $(.$class: ident)+ { $($content: tt)* } }) => {{
+        let style = make_tree!(@apply_style $style; $($class)*);
+        crate::layout::block::BlockContainerContent::Inline(
+            make_tree!(@build inline [&style;]; { $($content)* })
+        )
+    }};
     (@build_block_content [$style: expr;] { $($content: tt)* }) => {
         crate::layout::block::BlockContainerContent::Block(
             make_tree!(@build_all block [$style;]; $($content)*).into()

--- a/tests/layout/mod.rs
+++ b/tests/layout/mod.rs
@@ -9,6 +9,7 @@ mod input_edge_cases;
 mod line_break_anywhere;
 mod padding;
 mod ruby;
+mod shaping;
 mod text_decoration;
 mod text_shadow;
 mod whitespace;

--- a/tests/layout/shaping.rs
+++ b/tests/layout/shaping.rs
@@ -1,0 +1,63 @@
+use rasterize::color::BGRA8;
+use util::{math::I26Dot6, rc_static};
+
+use crate::style::computed::HorizontalAlignment;
+
+use super::common::*;
+
+test_define_style! {
+    .fs32 {
+        font_size: I26Dot6::new(32)
+    }
+
+    .red { color: BGRA8::RED }
+    .green { color: BGRA8::GREEN }
+
+    .align_right {
+        text_align: HorizontalAlignment::Right
+    }
+
+    .noto_arabic_ahem_emoji {
+        font_family: rc_static!([
+            rc_static!(str b"Noto Sans Arabic"),
+            rc_static!(str b"Ahem"),
+            rc_static!(str b"Noto Color Emoji")
+        ])
+    }
+
+    .noto_serif_ahem_emoji {
+        font_family: rc_static!([
+            rc_static!(str b"Noto Serif"),
+            rc_static!(str b"Ahem"),
+            rc_static!(str b"Noto Color Emoji")
+        ])
+    }
+}
+
+check_test! {
+    name = edge_reshaping,
+    size = (165, 230),
+    block.ahem {
+        block {
+            inline.noto_arabic_ahem_emoji.align_right.fs32 {
+                span.red {
+                    text "⭕️لمّا كا ا⭕️\n"
+                }
+                span.green {
+                    text "🧱لمّا كا ا🧱"
+                }
+            }
+        }
+
+        block {
+            inline.noto_serif_ahem_emoji.fs32 {
+                span.red {
+                    text "⭕️EDGE⭕️\n"
+                }
+                span.green {
+                    text "🧱EDGE🧱"
+                }
+            }
+        }
+    }
+}

--- a/tests/layout/snapshots/shaping_edge_reshaping.png.ptr
+++ b/tests/layout/snapshots/shaping_edge_reshaping.png.ptr
@@ -1,0 +1,5 @@
+file-hash a4c5695104f1fe2b65416bb568d8fd6f2d7acda04e8e497e91b731303695f459
+file-size 9514
+pixels 211dea85fa47afc5433fbdeff1e0382527bce07c2b230fb063a38f9af4e46edd
+width 165
+height 230


### PR DESCRIPTION
### Story time

So once upon a time a library called "HarfBuzz" was created. This library handled text shaping very well and many serious GUI programs started using it. Said library's main entrypoint is `hb_shape` which takes a buffer of codepoints along with an array of font features and outputs shaped glyphs in *visual order*. Here developers of users of HarfBuzz, like subrandr or Chromium, say "okay well I'll keep them in visual order". Unbeknownst to them, they have just fallen prey to impeccable **bait** laid out by HarfBuzz. In fact, a higher-level layout engine **does not** benefit from storing glyphs in visual order. The opposite happens: your code is now littered with `isLtr()` or `!self.direction.is_reverse()`.

Line breaking: happens on the text in *logical order*.
Hanging white space: the white space at the *logical end* of a line is hanged.
Splitting the glyph string across spans: if done on *logical order* glyphs, it will be naturally mirrored on reverse strings.

So yeah just pay the cost of reversing the glyphs and avoid the cost of juggling iteration order later. Having things be clean and logical also ends up simplifying some cases.

> [!NOTE]
> I am not the first to realize this, the first thing Firefox does is call `hb_buffer_reverse` if the direction was right to left.

### In other news

Switched `GlyphString` to use a `Vec` since fighting with `LinkedList` without cursors is too much of a pain here, it's probably faster anyway. Also simplified shaping parameter flow and splitting of text across spans.

I'm going to go back to improving white space handling on top of this PR now (which will hopefully make it much simpler). Will finish this once I'm confident this is the right approach. Alternatively I might realize I'm wrong and somehow visual order is better but I doubt that.