### PR TITLE
Add a subtitle event iterator API

### DIFF
--- a/include/subrandr.h
+++ b/include/subrandr.h
@@ -70,6 +70,67 @@ sbr_subtitles *sbr_load_text(sbr_library *, char const *content,
                              size_t content_len, sbr_subtitle_format format,
                              char const *language_hint);
 
+// Iterator for subtitle events of an `sbr_subtitles` object.
+//
+// The size of this struct is not part of the public ABI,
+// new fields may be added in ABI-compatible releases.
+typedef struct sbr_subtitle_iterator {
+  // Whether the iterator currently points to a subtitle event.
+  //
+  // Set to `true` once the end of an event list is reached and after
+  // initialization.
+  //
+  // Accessors for subtitle event data like `sbr_subtitle_iterator_get_text`
+  // must not be called if this flag is set.
+  bool exhausted;
+
+  // Start time of this subtitle event in milliseconds.
+  uint32_t start;
+  // End time of this subtitle event in milliseconds.
+  uint32_t end;
+} sbr_subtitle_iterator;
+
+// Construct a new subtitle event iterator.
+sbr_subtitle_iterator *sbr_subtitle_iterator_new(void);
+
+// Advance this iterator to the next subtitle event.
+//
+// Note that the order of events in an `sbr_subtitles` object is unspecified
+// so this event might not be after the current one time-wise.
+void sbr_subtitle_iterator_next(sbr_subtitle_iterator *);
+
+// Get the text content of this subtitle event.
+//
+// Text formatting will be ignored and not present in the result.
+// Ruby will use parenthesized fallback form like "嗚呼(ああ)".
+//
+// `flags` must be zero.
+//
+// The returned string is guaranteed to be valid for as long as
+// no other subrandr function is called on this iterator.
+char const *sbr_subtitle_iterator_get_text(sbr_subtitle_iterator *,
+                                           uint64_t flags);
+
+// Stop iterating the subtitle event list the iterator currently points to.
+//
+// Should be done as soon as you are done using the iterator to avoid keeping
+// resources alive unnecessarily as well as for future-proofing code to work
+// with a future incremental parsing API.
+void sbr_subtitle_iterator_reset(sbr_subtitle_iterator *);
+
+void sbr_subtitle_iterator_destroy(sbr_subtitle_iterator *);
+
+// Point the passed iterator to the beggining of the subtitle event list
+// of this subtitle object.
+//
+// The order of events inside this internal list is unspecified.
+void sbr_subtitles_iter(sbr_subtitles *, sbr_subtitle_iterator *);
+
+#if 0 /* <-- so clangd doesn't think this is a doc comment :) */
+// TODO: `sbr_subtitles_iter_at` would presumably be useful for some.
+// void sbr_subtitles_iter_at(sbr_subtitle_iterator *, uint32_t point);
+#endif
+
 void sbr_subtitles_destroy(sbr_subtitles *);
 
 sbr_renderer *sbr_renderer_create(sbr_library *);

--- a/sbr-util/src/rc/base.rs
+++ b/sbr-util/src/rc/base.rs
@@ -345,6 +345,11 @@ impl<R: Refcount, T: ?Sized> RcBase<R, T> {
     pub fn ptr_eq(this: &Self, other: &Self) -> bool {
         std::ptr::eq(this.ptr.as_ptr() as *mut (), other.ptr.as_ptr() as *mut ())
     }
+
+    #[inline]
+    pub fn as_ptr(this: &Self) -> *const T {
+        unsafe { &raw const (*this.ptr.as_ptr()).value }
+    }
 }
 
 impl<R: Refcount, T> From<T> for RcBase<R, T> {

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -3,8 +3,6 @@ use std::{
     cell::UnsafeCell,
     ffi::{c_char, CStr, CString},
     fmt::Formatter,
-    mem::MaybeUninit,
-    sync::Arc,
 };
 
 use icu_locale::{LanguageIdentifier, LocaleCanonicalizer};
@@ -320,23 +318,6 @@ unsafe extern "C" fn sbr_get_last_error_string() -> *const c_char {
             .as_ref()
             .map_or(std::ptr::null(), |e| e.string.as_ptr())
     })
-}
-
-#[unsafe(no_mangle)]
-unsafe extern "C" fn sbr_library_open_font_from_memory(
-    _lib: *mut CLibrary,
-    data: *const u8,
-    data_len: usize,
-) -> *mut Face {
-    let mut uninit = Arc::new_uninit_slice(data_len);
-    unsafe {
-        std::mem::transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(
-            Arc::get_mut(&mut uninit).unwrap(),
-        )
-        .copy_from_slice(std::slice::from_raw_parts(data, data_len));
-    }
-    let bytes = Arc::<[MaybeUninit<u8>]>::assume_init(uninit);
-    Box::into_raw(Box::new(ctry!(Face::load_from_bytes(bytes, 0))))
 }
 
 #[unsafe(no_mangle)]

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -1,15 +1,9 @@
 use std::{
     borrow::Cow,
     cell::UnsafeCell,
-    ffi::{c_char, CStr, CString},
+    ffi::{c_char, CString},
     fmt::Formatter,
 };
-
-use icu_locale::{LanguageIdentifier, LocaleCanonicalizer};
-use log::{debug, warn};
-use util::rc::Rc;
-
-use crate::{capi::library::CLibrary, Subtitles};
 
 macro_rules! c_enum {
     (
@@ -32,10 +26,10 @@ macro_rules! c_enum {
                 }
             }
 
-            $(fn try_from_value(value: $type) -> Result<Self, CError> {
+            $(fn try_from_value(value: $type) -> Result<Self, $crate::capi::CError> {
                 Self::from_value(value).ok_or_else(||
-                    CError::new(
-                        ErrorKind::$try_from_kind,
+                    $crate::capi::CError::new(
+                        $crate::capi::ErrorKind::$try_from_kind,
                         format!($try_from_fmtstr, value = value)
                     )
                 )
@@ -157,28 +151,6 @@ impl CErrorReturn for i16 {
     }
 }
 
-c_enum! {
-    #[repr(i16)]
-    #[try_from(InvalidArgument, "{value} is not a valid subtitle format")]
-    enum SubtitleFormat {
-        Unknown = 0,
-        Srv3 = 1,
-        WebVTT = 2
-    }
-}
-
-// TODO: This should be pulled out into the main module if a Rust API is desired
-//       in the future.
-fn probe(content: &str) -> SubtitleFormat {
-    if crate::srv3::probe(content) {
-        SubtitleFormat::Srv3
-    } else if crate::vtt::probe(content) {
-        SubtitleFormat::WebVTT
-    } else {
-        SubtitleFormat::Unknown
-    }
-}
-
 macro_rules! cthrow {
     ($error: expr) => {{
         return {
@@ -220,96 +192,9 @@ macro_rules! ctrywrap {
 
 mod library;
 mod renderer;
+mod subtitles;
 #[cfg(target_arch = "wasm32")]
 mod wasm;
-
-#[unsafe(no_mangle)]
-unsafe extern "C" fn sbr_probe_text(content: *const c_char, content_len: usize) -> SubtitleFormat {
-    let Ok(content) = std::str::from_utf8(std::slice::from_raw_parts(
-        content.cast::<u8>(),
-        content_len,
-    )) else {
-        return SubtitleFormat::Unknown;
-    };
-
-    probe(content)
-}
-
-#[unsafe(no_mangle)]
-unsafe extern "C" fn sbr_load_text(
-    lib: &CLibrary,
-    content: *const c_char,
-    content_len: usize,
-    format: i16,
-    language_hint: *const c_char,
-) -> *mut Subtitles {
-    let mut format = ctry!(SubtitleFormat::try_from_value(format));
-    let content = ctrywrap!(
-        Other("Invalid UTF-8"),
-        std::str::from_utf8(std::slice::from_raw_parts(
-            content.cast::<u8>(),
-            content_len
-        ))
-    );
-    let log = lib.root_logger.new_ctx();
-    let language_hint = if !language_hint.is_null() {
-        let cstr = CStr::from_ptr(language_hint);
-        match LanguageIdentifier::try_from_locale_bytes(cstr.to_bytes()) {
-            Ok(lang_id) => {
-                let mut locale = icu_locale::Locale {
-                    id: lang_id,
-                    extensions: icu_locale::extensions::Extensions::new(),
-                };
-                // NOTE: Locale canonicalization is performed here because YouTube uses
-                //       the obsolete "iw" language tag for Hebrew which identifies itself
-                //       as `LeftToRight` with `icu_locale::LocaleDirectionality`.
-                //       This step converts "iw" to "he" which is correctly `RightToLeft`.
-                //       There probably exist other good reasons for doing this and it avoids
-                //       special casing "iw" internally.
-                LocaleCanonicalizer::new_common().canonicalize(&mut locale);
-                debug!(log, "Language hint resolved to {:?}", locale.id);
-                Some(locale.id)
-            }
-            Err(error) => {
-                warn!(log, "Failed to parse language hint {cstr:?}: {error}");
-                None
-            }
-        }
-    } else {
-        None
-    };
-
-    if format == SubtitleFormat::Unknown {
-        format = probe(content);
-    }
-
-    match format {
-        SubtitleFormat::Srv3 => Box::into_raw(Box::new(Subtitles::Srv3(Rc::new(ctry!(
-            crate::srv3::convert(
-                &log,
-                ctry!(crate::srv3::parse(&log, content)),
-                language_hint.as_ref(),
-            )
-        ))))),
-        SubtitleFormat::WebVTT => {
-            Box::into_raw(Box::new(Subtitles::Vtt(Rc::new(crate::vtt::convert(
-                &log,
-                match crate::vtt::parse(content) {
-                    Some(captions) => captions,
-                    None => cthrow!(Other, "Invalid WebVTT"),
-                },
-            )))))
-        }
-        SubtitleFormat::Unknown => {
-            cthrow!(UnrecognizedFormat, "Unrecognized subtitle format")
-        }
-    }
-}
-
-#[unsafe(no_mangle)]
-unsafe extern "C" fn sbr_subtitles_destroy(subtitles: *mut Subtitles) {
-    drop(Box::from_raw(subtitles));
-}
 
 #[unsafe(no_mangle)]
 unsafe extern "C" fn sbr_get_last_error_string() -> *const c_char {

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -9,7 +9,7 @@ use icu_locale::{LanguageIdentifier, LocaleCanonicalizer};
 use log::{debug, warn};
 use util::rc::Rc;
 
-use crate::{capi::library::CLibrary, text::Face, Subtitles};
+use crate::{capi::library::CLibrary, Subtitles};
 
 macro_rules! c_enum {
     (
@@ -318,9 +318,4 @@ unsafe extern "C" fn sbr_get_last_error_string() -> *const c_char {
             .as_ref()
             .map_or(std::ptr::null(), |e| e.string.as_ptr())
     })
-}
-
-#[unsafe(no_mangle)]
-unsafe extern "C" fn sbr_library_close_font(_lib: *mut CLibrary, font: *mut Face) {
-    std::mem::forget((*font).clone());
 }

--- a/src/capi/renderer/instanced.rs
+++ b/src/capi/renderer/instanced.rs
@@ -47,7 +47,7 @@ unsafe extern "C" fn sbr_renderer_render_instanced(
     if flags != 0 {
         cthrow!(
             InvalidArgument,
-            "non-zero flags parameter passed to `sbr_renderer_render_instanced`"
+            "non-zero flags passed to `sbr_renderer_render_instanced`"
         );
     }
 

--- a/src/capi/subtitles.rs
+++ b/src/capi/subtitles.rs
@@ -4,7 +4,7 @@ use icu_locale::{LanguageIdentifier, LocaleCanonicalizer};
 use log::{debug, warn};
 use util::rc::Rc;
 
-use crate::{capi::library::CLibrary, Subtitles};
+use crate::{capi::library::CLibrary, renderer::SubtitleEvent, srv3, vtt, Subtitles};
 
 c_enum! {
     #[repr(i16)]
@@ -114,4 +114,158 @@ unsafe extern "C" fn sbr_load_text(
 #[unsafe(no_mangle)]
 unsafe extern "C" fn sbr_subtitles_destroy(subtitles: *mut Subtitles) {
     drop(Box::from_raw(subtitles));
+}
+
+#[repr(C)]
+struct CSubtitleIteratorPublic {
+    exhausted: bool,
+    start: u32,
+    end: u32,
+}
+
+impl CSubtitleIteratorPublic {
+    fn update(&mut self, current: Option<impl SubtitleEvent>) {
+        let Some(event) = current else {
+            self.exhausted = true;
+            return;
+        };
+
+        self.exhausted = false;
+        let range = event.time_range();
+        self.start = range.start;
+        self.end = range.end;
+    }
+}
+
+#[repr(C)]
+struct CSubtitleIterator {
+    public: CSubtitleIteratorPublic,
+    /* Public fields end here */
+    text_buffer: String,
+    inner: Option<(Subtitles, CSubtitleIteratorImpl<'static>)>,
+}
+
+enum CSubtitleIteratorImpl<'a> {
+    Srv3(StatefulIterator<srv3::SubtitleIterator<'a>>),
+    Vtt(StatefulIterator<vtt::SubtitleIterator<'a>>),
+}
+
+struct StatefulIterator<I: Iterator<Item: SubtitleEvent + Copy>> {
+    current: Option<I::Item>,
+    inner: I,
+}
+
+impl<I: Iterator<Item: SubtitleEvent + Copy>> StatefulIterator<I> {
+    fn new(inner: I) -> Self {
+        Self {
+            current: None,
+            inner,
+        }
+    }
+}
+
+impl<I: Iterator<Item: SubtitleEvent + Copy>> StatefulIterator<I> {
+    fn text(&self, output: &mut String) -> Option<()> {
+        self.current.as_ref().map(|event| {
+            event.text(output);
+        })
+    }
+
+    fn advance(&mut self, public: &mut CSubtitleIteratorPublic) {
+        self.current = self.inner.next();
+        public.update(self.current);
+    }
+}
+
+impl CSubtitleIteratorImpl<'_> {
+    fn text(&self, output: &mut String) -> Option<()> {
+        match self {
+            CSubtitleIteratorImpl::Srv3(srv3) => srv3.text(output),
+            CSubtitleIteratorImpl::Vtt(vtt) => vtt.text(output),
+        }
+    }
+
+    fn advance(&mut self, public: &mut CSubtitleIteratorPublic) {
+        match self {
+            CSubtitleIteratorImpl::Srv3(srv3) => srv3.advance(public),
+            CSubtitleIteratorImpl::Vtt(vtt) => vtt.advance(public),
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn sbr_subtitle_iterator_new() -> *mut CSubtitleIterator {
+    Box::into_raw(Box::new(CSubtitleIterator {
+        public: CSubtitleIteratorPublic {
+            exhausted: true,
+            start: 0,
+            end: 0,
+        },
+        text_buffer: String::new(),
+        inner: None,
+    }))
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn sbr_subtitle_iterator_next(this: *mut CSubtitleIterator) {
+    let Some((_, iter)) = &mut (*this).inner else {
+        return;
+    };
+
+    iter.advance(&mut (*this).public);
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn sbr_subtitle_iterator_get_text(
+    this: *mut CSubtitleIterator,
+    flags: u64,
+) -> *const c_char {
+    if flags != 0 {
+        cthrow!(
+            InvalidArgument,
+            "non-zero flags passed to `sbr_subtitle_iterator_get_text`"
+        );
+    }
+
+    let Some((_, iter)) = &mut (*this).inner else {
+        return std::ptr::null();
+    };
+
+    (*this).text_buffer.clear();
+    match iter.text(&mut (*this).text_buffer) {
+        Some(()) => {
+            (*this).text_buffer.push('\0');
+            (*this).text_buffer.as_ptr() as _
+        }
+        None => std::ptr::null(),
+    }
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn sbr_subtitle_iterator_reset(this: *mut CSubtitleIterator) {
+    (*this).public.exhausted = true;
+    (*this).inner = None;
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn sbr_subtitle_iterator_destroy(this: *mut CSubtitleIterator) {
+    drop(Box::from_raw(this));
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn sbr_subtitles_iter(this: *mut Subtitles, citer: *mut CSubtitleIterator) {
+    let subs = (*this).clone();
+    // NOTE: This whole `Rc::as_ptr` dance is to avoid any potential "technically UB"
+    //       references by going through the internal raw pointer directly.
+    let mut iter: CSubtitleIteratorImpl<'static> = match &subs {
+        Subtitles::Srv3(srv3) => {
+            CSubtitleIteratorImpl::Srv3(StatefulIterator::new((*Rc::as_ptr(srv3)).iter()))
+        }
+        Subtitles::Vtt(vtt) => {
+            CSubtitleIteratorImpl::Vtt(StatefulIterator::new((*Rc::as_ptr(vtt)).iter()))
+        }
+    };
+
+    iter.advance(&mut (*citer).public);
+    (*citer).inner = Some((subs, iter));
 }

--- a/src/capi/subtitles.rs
+++ b/src/capi/subtitles.rs
@@ -1,0 +1,117 @@
+use std::ffi::{c_char, CStr};
+
+use icu_locale::{LanguageIdentifier, LocaleCanonicalizer};
+use log::{debug, warn};
+use util::rc::Rc;
+
+use crate::{capi::library::CLibrary, Subtitles};
+
+c_enum! {
+    #[repr(i16)]
+    #[try_from(InvalidArgument, "{value} is not a valid subtitle format")]
+    enum SubtitleFormat {
+        Unknown = 0,
+        Srv3 = 1,
+        WebVTT = 2
+    }
+}
+
+// TODO: This should be pulled out into the main module if a Rust API is desired
+//       in the future.
+fn probe(content: &str) -> SubtitleFormat {
+    if crate::srv3::probe(content) {
+        SubtitleFormat::Srv3
+    } else if crate::vtt::probe(content) {
+        SubtitleFormat::WebVTT
+    } else {
+        SubtitleFormat::Unknown
+    }
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn sbr_probe_text(content: *const c_char, content_len: usize) -> SubtitleFormat {
+    let Ok(content) = std::str::from_utf8(std::slice::from_raw_parts(
+        content.cast::<u8>(),
+        content_len,
+    )) else {
+        return SubtitleFormat::Unknown;
+    };
+
+    probe(content)
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn sbr_load_text(
+    lib: &CLibrary,
+    content: *const c_char,
+    content_len: usize,
+    format: i16,
+    language_hint: *const c_char,
+) -> *mut Subtitles {
+    let mut format = ctry!(SubtitleFormat::try_from_value(format));
+    let content = ctrywrap!(
+        Other("Invalid UTF-8"),
+        std::str::from_utf8(std::slice::from_raw_parts(
+            content.cast::<u8>(),
+            content_len
+        ))
+    );
+    let log = lib.root_logger.new_ctx();
+    let language_hint = if !language_hint.is_null() {
+        let cstr = CStr::from_ptr(language_hint);
+        match LanguageIdentifier::try_from_locale_bytes(cstr.to_bytes()) {
+            Ok(lang_id) => {
+                let mut locale = icu_locale::Locale {
+                    id: lang_id,
+                    extensions: icu_locale::extensions::Extensions::new(),
+                };
+                // NOTE: Locale canonicalization is performed here because YouTube uses
+                //       the obsolete "iw" language tag for Hebrew which identifies itself
+                //       as `LeftToRight` with `icu_locale::LocaleDirectionality`.
+                //       This step converts "iw" to "he" which is correctly `RightToLeft`.
+                //       There probably exist other good reasons for doing this and it avoids
+                //       special casing "iw" internally.
+                LocaleCanonicalizer::new_common().canonicalize(&mut locale);
+                debug!(log, "Language hint resolved to {:?}", locale.id);
+                Some(locale.id)
+            }
+            Err(error) => {
+                warn!(log, "Failed to parse language hint {cstr:?}: {error}");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    if format == SubtitleFormat::Unknown {
+        format = probe(content);
+    }
+
+    match format {
+        SubtitleFormat::Srv3 => Box::into_raw(Box::new(Subtitles::Srv3(Rc::new(ctry!(
+            crate::srv3::convert(
+                &log,
+                ctry!(crate::srv3::parse(&log, content)),
+                language_hint.as_ref(),
+            )
+        ))))),
+        SubtitleFormat::WebVTT => {
+            Box::into_raw(Box::new(Subtitles::Vtt(Rc::new(crate::vtt::convert(
+                &log,
+                match crate::vtt::parse(content) {
+                    Some(captions) => captions,
+                    None => cthrow!(Other, "Invalid WebVTT"),
+                },
+            )))))
+        }
+        SubtitleFormat::Unknown => {
+            cthrow!(UnrecognizedFormat, "Unrecognized subtitle format")
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn sbr_subtitles_destroy(subtitles: *mut Subtitles) {
+    drop(Box::from_raw(subtitles));
+}

--- a/src/capi/wasm.rs
+++ b/src/capi/wasm.rs
@@ -91,3 +91,8 @@ pub unsafe extern "C" fn sbr_wasm_renderer_add_font(
         source: crate::text::FontSource::Memory((*font).clone()),
     });
 }
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn sbr_wasm_close_font(font: *mut Face) {
+    std::mem::forget((*font).clone());
+}

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -73,6 +73,21 @@ pub enum Subtitles {
     Vtt(Rc<vtt::Subtitles>),
 }
 
+pub trait SubtitleEvent {
+    fn time_range(&self) -> Range<u32>;
+    fn text(&self, output: &mut String);
+}
+
+impl<T: SubtitleEvent> SubtitleEvent for &T {
+    fn time_range(&self) -> Range<u32> {
+        T::time_range(self)
+    }
+
+    fn text(&self, output: &mut String) {
+        T::text(self, output)
+    }
+}
+
 enum FormatLayouter {
     Srv3(srv3::Layouter),
     Vtt(vtt::Layouter),

--- a/src/srv3/convert.rs
+++ b/src/srv3/convert.rs
@@ -15,7 +15,7 @@ use crate::{
         inline::{InlineContent, InlineContentBuilder, InlineSpanBuilder},
         FixedL, InlineLayoutError, LayoutConstraints, Point2L, Vec2L,
     },
-    renderer::FrameLayoutPass,
+    renderer::{FrameLayoutPass, SubtitleEvent},
     srv3::{BodyParser, Event, ModeHint, RubyPosition},
     style::{
         computed::{
@@ -192,7 +192,9 @@ struct Window {
 }
 
 #[derive(Debug)]
-struct VisualLine {
+// NOTE: Only public for SubtitleEvent, don't use by name
+#[doc(hidden)]
+pub struct VisualLine {
     range: Range<u32>,
     segments: Vec<LineSegment>,
 }
@@ -739,6 +741,61 @@ pub fn convert(
     }
 
     Ok(result)
+}
+
+impl Subtitles {
+    pub fn iter(&self) -> SubtitleIterator<'_> {
+        SubtitleIterator {
+            windows: self.windows.iter(),
+            lines: [].iter(),
+        }
+    }
+}
+
+pub struct SubtitleIterator<'a> {
+    windows: std::slice::Iter<'a, Window>,
+    lines: std::slice::Iter<'a, VisualLine>,
+}
+
+impl<'a> Iterator for SubtitleIterator<'a> {
+    // TODO: I now understand what `impl_trait_in_assoc_type` is useful for.
+    //       `type_alias_impl_trait` would allow getting rid of this struct entirely.
+    type Item = &'a VisualLine;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let Some(line) = self.lines.next() else {
+                match self.windows.next() {
+                    Some(w) => {
+                        self.lines = w.lines.iter();
+                        continue;
+                    }
+                    None => {
+                        return None;
+                    }
+                }
+            };
+
+            return Some(line);
+        }
+    }
+}
+
+impl SubtitleEvent for VisualLine {
+    fn time_range(&self) -> Range<u32> {
+        self.range.clone()
+    }
+
+    fn text(&self, output: &mut String) {
+        for segment in &self.segments {
+            output.push_str(&segment.inner.text);
+            if let Some(annotation) = &segment.annotation {
+                output.push('(');
+                output.push_str(&annotation.text);
+                output.push(')');
+            }
+        }
+    }
 }
 
 pub(crate) struct Layouter {

--- a/src/text/face.rs
+++ b/src/text/face.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, hash::Hash, ops::RangeInclusive, path::Path, sync::Arc};
+use std::{fmt::Debug, hash::Hash, ops::RangeInclusive, path::Path};
 
 use rasterize::{Rasterizer, Texture};
 use text_sys::hb_font_t;
@@ -169,7 +169,11 @@ impl Face {
         freetype::Face::load_from_file(path, index).map(Face::FreeType)
     }
 
-    pub fn load_from_bytes(bytes: Arc<[u8]>, index: i32) -> Result<Self, FreeTypeError> {
+    #[cfg_attr(
+        not(any(target_arch = "wasm32", font_provider = "directwrite")),
+        expect(dead_code)
+    )]
+    pub fn load_from_bytes(bytes: std::sync::Arc<[u8]>, index: i32) -> Result<Self, FreeTypeError> {
         freetype::Face::load_from_bytes(bytes, index).map(Face::FreeType)
     }
 

--- a/src/vtt/convert.rs
+++ b/src/vtt/convert.rs
@@ -15,7 +15,7 @@ use crate::{
         inline::{InlineContentBuilder, InlineContentFragment, InlineSpanBuilder, LineBoxFragment},
         FixedL, InlineLayoutError, Point2L, Vec2L,
     },
-    renderer::FrameLayoutPass,
+    renderer::{FrameLayoutPass, SubtitleEvent},
     style::{
         computed::{FontSlant, HorizontalAlignment, TextDecorations},
         ComputedStyle,
@@ -98,7 +98,9 @@ impl vtt::Cue<'_> {
 }
 
 #[derive(Debug)]
-struct Event {
+// NOTE: Only public for SubtitleEvent, don't use by name
+#[doc(hidden)]
+pub struct Event {
     range: Range<u32>,
     writing_direction: vtt::WritingDirection,
     text_alignment: vtt::TextAlignment,
@@ -625,6 +627,59 @@ pub fn convert(log: &LogContext, captions: vtt::Captions) -> Subtitles {
     }
 
     subtitles
+}
+
+impl Subtitles {
+    pub fn iter(&self) -> SubtitleIterator<'_> {
+        SubtitleIterator(self.events.iter())
+    }
+}
+
+pub struct SubtitleIterator<'a>(std::slice::Iter<'a, Event>);
+
+impl<'a> Iterator for SubtitleIterator<'a> {
+    type Item = &'a Event;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl SubtitleEvent for Event {
+    fn time_range(&self) -> Range<u32> {
+        self.range.clone()
+    }
+
+    fn text(&self, output: &mut String) {
+        struct Visitor<'o> {
+            output: &'o mut String,
+        }
+
+        impl Visitor<'_> {
+            fn visit_text(&mut self, text: &str) {
+                self.output.push_str(text);
+            }
+
+            fn visit_element(&mut self, element: &Element) {
+                if let ElementKind::RubyText = element.kind {
+                    self.output.push('(');
+                }
+
+                for child in &element.children {
+                    match child {
+                        Node::Text(text) => self.visit_text(text),
+                        Node::Element(child_element) => self.visit_element(child_element),
+                    }
+                }
+
+                if let ElementKind::RubyText = element.kind {
+                    self.output.push(')');
+                }
+            }
+        }
+
+        Visitor { output }.visit_element(&self.root);
+    }
 }
 
 pub(crate) struct Layouter {

--- a/wasi32/src/module.ts
+++ b/wasi32/src/module.ts
@@ -27,7 +27,6 @@ export interface SubrandrExports {
 	// C API
 	sbr_library_init(): LibraryPtr
 	sbr_library_fini(ptr: LibraryPtr): void
-	sbr_library_close_font(sbr: LibraryPtr, ptr: FontPtr): void
 	sbr_load_text(
 		ptr: LibraryPtr,
 		text_ptr: WasmPtr, text_len: number,
@@ -66,6 +65,7 @@ export interface SubrandrExports {
 		front: WasmPtr, back: WasmPtr,
 		width: number, height: number
 	): void
+	sbr_wasm_close_font(ptr: FontPtr): void
 }
 
 export interface OutputStream {

--- a/wasi32/src/subrandr.ts
+++ b/wasi32/src/subrandr.ts
@@ -141,7 +141,7 @@ export class Font {
 
   close() {
     const g = state();
-    g.mod.exports.sbr_library_close_font(g.lib, this.__ptr)
+    g.mod.exports.sbr_wasm_close_font(this.__ptr)
     this.__ptr = WASM_NULL as FontPtr
   }
 }


### PR DESCRIPTION
Allows for.. things.

It would be more useful if we could guarantee a sorted iteration order but that's not how subtitles are currently stored.

Tested with https://github.com/afishhh/mpv/tree/sbr-sub-lines.

Fixes https://github.com/afishhh/subrandr/issues/155