### PR TITLE
Fix `FcConfig` refcounting

### DIFF
--- a/src/text/platform_font_provider/fontconfig.rs
+++ b/src/text/platform_font_provider/fontconfig.rs
@@ -75,37 +75,32 @@ pub enum FallbackError {
 
 impl FontconfigFontProvider {
     pub fn new() -> Result<Self, NewError> {
-        unsafe {
-            // Before this version fontconfig was not thread-safe, we share a single
-            // global PlatformFontProvider so we want it to be thread safe.
-            // This version was released 12 years ago so it's really just a sanity check.
-            if FcGetVersion() < 21091 {
-                return Err(NewError::Outdated);
-            }
-
-            let config = FcConfigGetCurrent();
-            if config.is_null() {
-                return Err(NewError::Init);
-            }
-
-            Ok({
-                let mut result = Self {
-                    config,
-                    fonts: Vec::new(),
-                };
-                result.update_font_list()?;
-                result
-            })
+        // Before this version fontconfig was not thread-safe, we share a single
+        // global PlatformFontProvider so we want it to be thread safe.
+        // This version was released 12 years ago so it's really just a sanity check.
+        if unsafe { FcGetVersion() } < 21091 {
+            return Err(NewError::Outdated);
         }
+
+        let config = unsafe { FcConfigReference(std::ptr::null_mut()) };
+        if config.is_null() {
+            return Err(NewError::Init);
+        }
+
+        Ok({
+            let mut result = Self {
+                config,
+                fonts: Vec::new(),
+            };
+            result.update_font_list()?;
+            result
+        })
     }
 }
 
 impl Drop for FontconfigFontProvider {
     fn drop(&mut self) {
-        unsafe {
-            FcConfigDestroy(self.config);
-            FcFini();
-        };
+        unsafe { FcConfigDestroy(self.config) };
     }
 }
 
@@ -231,15 +226,18 @@ impl PlatformFontProvider for FontconfigFontProvider {
             return Err(UpdateError::BringUpToDate.into());
         }
 
-        let current = unsafe { FcConfigGetCurrent() };
-        Ok(if current != self.config {
-            info!(log, "Fontconfig configuration updated, reloading font list");
-            self.config = current;
-            self.update_font_list()?;
-            true
-        } else {
-            false
-        })
+        let new = unsafe { FcConfigReference(std::ptr::null_mut()) };
+        if new == self.config {
+            unsafe { FcConfigDestroy(new) }
+            return Ok(false);
+        }
+
+        info!(log, "Fontconfig configuration updated, reloading font list");
+        unsafe { FcConfigDestroy(self.config) }
+        self.config = new;
+        self.update_font_list()?;
+
+        Ok(true)
     }
 
     fn substitute(

--- a/src/text/platform_font_provider/fontconfig/weight.rs
+++ b/src/text/platform_font_provider/fontconfig/weight.rs
@@ -25,7 +25,7 @@ pub fn map_fontconfig_weight_to_opentype(fc_weight: I16Dot16) -> Option<I16Dot16
 
     let i = WEIGHT_MAP
         .binary_search_by(|x| x.0.partial_cmp(&fc_weight).unwrap())
-        .map_or_else(std::convert::identity, std::convert::identity);
+        .unwrap_or_else(std::convert::identity);
 
     if WEIGHT_MAP[i].0 == fc_weight {
         return Some(WEIGHT_MAP[i].1);
@@ -53,7 +53,7 @@ pub fn map_opentype_weight_to_fontconfig(ot_weight: I16Dot16) -> Option<I16Dot16
 
     let i = WEIGHT_MAP
         .binary_search_by(|x| x.1.partial_cmp(&ot_weight).unwrap())
-        .map_or_else(std::convert::identity, std::convert::identity);
+        .unwrap_or_else(std::convert::identity);
 
     if WEIGHT_MAP[i].1 == ot_weight {
         return Some(WEIGHT_MAP[i].0);


### PR DESCRIPTION
Makes `FcConfig` refcounting in `FontconfigFontProvider` less blatantly MT-unsafe.

This still uses fontconfig global state and "leaks" memory. While recently fontconfig took steps to making `FcFini` library/MT-safe but it seems they're failing at it pretty hard and it's not actually MT-safe so we avoid it.

The font provider could be made to not use global state but it'd "leak" stuff anyway since static destructors are never actually called in Rust so the font provider would have to stop being global.