### PR TITLE
Make outlines go FAST

### DIFF
--- a/sbr-rasterize/src/color.rs
+++ b/sbr-rasterize/src/color.rs
@@ -80,7 +80,7 @@ pub trait Premultiply: Debug + Clone + Copy {
     fn premultiply(self) -> Premultiplied<Self>;
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Premultiplied<T: Premultiply>(pub T);
 

--- a/sbr-rasterize/src/rasterizer.rs
+++ b/sbr-rasterize/src/rasterizer.rs
@@ -48,6 +48,12 @@ impl Texture {
             TextureInner::Software(sw) => sw.memory_footprint(),
         }
     }
+
+    pub(crate) fn is_mono(&self) -> bool {
+        match &self.0 {
+            TextureInner::Software(sw) => matches!(sw.format(), PixelFormat::Mono),
+        }
+    }
 }
 
 #[derive(Debug, Error)]

--- a/sbr-rasterize/src/rasterizer.rs
+++ b/sbr-rasterize/src/rasterizer.rs
@@ -43,21 +43,9 @@ impl TextureInner {
 pub struct Texture(TextureInner);
 
 impl Texture {
-    pub fn memory_footprint(&self) -> usize {
+    pub(crate) fn memory_footprint(&self) -> usize {
         match &self.0 {
             TextureInner::Software(sw) => sw.memory_footprint(),
-        }
-    }
-
-    pub(crate) fn width(&self) -> u32 {
-        match &self.0 {
-            TextureInner::Software(sw) => sw.width(),
-        }
-    }
-
-    pub(crate) fn height(&self) -> u32 {
-        match &self.0 {
-            TextureInner::Software(sw) => sw.height(),
         }
     }
 }

--- a/sbr-rasterize/src/rasterizer/sw.rs
+++ b/sbr-rasterize/src/rasterizer/sw.rs
@@ -489,6 +489,13 @@ impl<'a> Texture<'a> {
         self.height
     }
 
+    pub(crate) fn format(&self) -> PixelFormat {
+        match &self.data {
+            TextureData::OwnedMono(_) => PixelFormat::Mono,
+            TextureData::OwnedBgra(_) | TextureData::BorrowedMono(_) => PixelFormat::Bgra,
+        }
+    }
+
     pub fn memory_footprint(&self) -> usize {
         match &self.data {
             TextureData::OwnedMono(mono) => mono.len(),
@@ -1064,7 +1071,16 @@ impl Rasterizer {
                     let cache = self.cache.clone();
                     let new_active_color = subscene.active_color.compute(active_color);
                     if let SubsceneKind::Scene(scene) = &subscene.kind {
-                        if subscene.scene_filter.is_none() {
+                        let mut can_skip_texture = false;
+
+                        can_skip_texture |= subscene.scene_filter.is_none();
+                        // Unblurred `ExtractAlpha` from a mono scene is a no-op.
+                        can_skip_texture |= matches!(
+                            subscene.scene_filter,
+                            Some(SceneFilter::ExtractAlpha { blur_stddev }) if blur_stddev == FixedS::ZERO
+                        ) && scene.is_mono();
+
+                        if can_skip_texture {
                             let (pieces, _) = cache.get_or_render_scene_pieces(
                                 log,
                                 scene,

--- a/sbr-rasterize/src/rasterizer/sw.rs
+++ b/sbr-rasterize/src/rasterizer/sw.rs
@@ -385,9 +385,28 @@ impl PartialEq for TextureData<'_> {
 
 impl Eq for TextureData<'_> {}
 
+#[derive(Clone, Copy)]
 enum TextureDataRef<'a> {
     Mono(&'a [u8]),
     Bgra(&'a [Premultiplied<BGRA8>]),
+}
+
+impl TextureDataRef<'_> {
+    fn hash_content<H: std::hash::Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
+        match *self {
+            TextureDataRef::Mono(mono) => mono.hash(state),
+            TextureDataRef::Bgra(bgra) => bgra.hash(state),
+        }
+    }
+
+    fn eq_content(&self, other: &Self) -> bool {
+        match (*self, *other) {
+            (TextureDataRef::Mono(mono), TextureDataRef::Mono(other_mono)) => mono == other_mono,
+            (TextureDataRef::Bgra(bgra), TextureDataRef::Bgra(other_bgra)) => bgra == other_bgra,
+            _ => false,
+        }
+    }
 }
 
 trait TexturePixel: Sized {
@@ -496,7 +515,19 @@ impl<'a> Texture<'a> {
         }
     }
 
-    pub fn memory_footprint(&self) -> usize {
+    fn hash_content<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.width.hash(state);
+        self.height.hash(state);
+        self.data.as_ref().hash_content(state);
+    }
+
+    fn eq_content(&self, other: &Self) -> bool {
+        self.width == other.width
+            && self.height == other.height
+            && TextureDataRef::eq_content(&self.data.as_ref(), &other.data.as_ref())
+    }
+
+    pub(crate) fn memory_footprint(&self) -> usize {
         match &self.data {
             TextureData::OwnedMono(mono) => mono.len(),
             TextureData::OwnedBgra(bgra) => bgra.len() * 4,
@@ -946,12 +977,43 @@ impl super::Rasterizer for Rasterizer {
     }
 }
 
-#[derive(Clone, Hash, PartialEq, Eq)]
+#[derive(Clone)]
 pub struct OutputBitmap<'a> {
     pub texture: Texture<'a>,
     pub filter: Option<BitmapFilter>,
     pub color: BGRA8,
 }
+
+impl OutputBitmap<'_> {
+    fn compare_by_content(&self) -> bool {
+        (self.texture.width() as usize * self.texture.height() as usize) <= 64
+    }
+}
+
+impl Hash for OutputBitmap<'_> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        if self.compare_by_content() {
+            self.texture.hash_content(state);
+        } else {
+            self.texture.hash(state);
+        }
+        self.filter.hash(state);
+        self.color.hash(state);
+    }
+}
+
+impl PartialEq for OutputBitmap<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        (if self.compare_by_content() {
+            Texture::eq_content(&self.texture, &other.texture)
+        } else {
+            Texture::eq(&self.texture, &other.texture)
+        }) && self.filter == other.filter
+            && self.color == other.color
+    }
+}
+
+impl Eq for OutputBitmap<'_> {}
 
 #[derive(Clone)]
 pub struct OutputStrips {
@@ -1515,14 +1577,14 @@ pub fn pieces_to_instanced_images<'a, B: InstancedOutputBuilder<'a>>(
     clip_rect: Rect2<i32>,
     rasterizer: &mut Rasterizer,
 ) {
-    let mut texture_map = HashMap::<OutputBitmap<'static>, B::ImageHandle>::new();
+    let mut texture_map = HashMap::<OutputBitmap<'a>, B::ImageHandle>::new();
 
     for piece in pieces {
         let Some(clip_intersection) = clip_pixel_rects(piece.rect(), clip_rect) else {
             continue;
         };
 
-        let mut try_insert_bitmap = |bitmap: OutputBitmap<'static>| {
+        let mut try_insert_bitmap = |builder: &mut B, bitmap: OutputBitmap<'a>| {
             let occupied = match texture_map.entry(bitmap) {
                 std::collections::hash_map::Entry::Occupied(occupied) => occupied,
                 std::collections::hash_map::Entry::Vacant(vacant) => {
@@ -1538,7 +1600,7 @@ pub fn pieces_to_instanced_images<'a, B: InstancedOutputBuilder<'a>>(
         match &piece.content {
             OutputPieceContent::Texture(bitmap) => {
                 if piece.size == bitmap.texture.size() {
-                    let handle = try_insert_bitmap(bitmap.clone());
+                    let handle = try_insert_bitmap(builder, bitmap.clone());
                     builder.on_instance(handle, OutputInstanceParameters::from(clip_intersection));
                 } else {
                     let mut params = OutputInstanceParameters {
@@ -1562,12 +1624,15 @@ pub fn pieces_to_instanced_images<'a, B: InstancedOutputBuilder<'a>>(
                         );
                         params.src_off = clip_intersection.min_clip;
                         params.src_size = clip_intersection.size;
-                        try_insert_bitmap(OutputBitmap {
-                            texture: scaled,
-                            ..*bitmap
-                        })
+                        try_insert_bitmap(
+                            builder,
+                            OutputBitmap {
+                                texture: scaled,
+                                ..*bitmap
+                            },
+                        )
                     } else {
-                        try_insert_bitmap(bitmap.clone())
+                        try_insert_bitmap(builder, bitmap.clone())
                     };
 
                     builder.on_instance(handle, params);
@@ -1588,14 +1653,13 @@ pub fn pieces_to_instanced_images<'a, B: InstancedOutputBuilder<'a>>(
                     match op {
                         StripPaintOp::Copy(copy) => {
                             let texture = copy.to_texture();
-                            let size = texture.size();
-                            let handle = builder.on_image(
-                                size,
-                                OutputImage::Texture(OutputBitmap {
+                            let handle = try_insert_bitmap(
+                                builder,
+                                OutputBitmap {
                                     texture,
                                     filter: None,
                                     color: strips.color,
-                                }),
+                                },
                             );
                             builder.on_instance(
                                 handle,
@@ -1604,13 +1668,13 @@ pub fn pieces_to_instanced_images<'a, B: InstancedOutputBuilder<'a>>(
                         }
                         StripPaintOp::Fill(fill) => {
                             let texture = fill.to_vertical_texture();
-                            let handle = builder.on_image(
-                                texture.size(),
-                                OutputImage::Texture(OutputBitmap {
+                            let handle = try_insert_bitmap(
+                                builder,
+                                OutputBitmap {
                                     texture,
                                     filter: None,
                                     color: strips.color,
-                                }),
+                                },
                             );
                             builder.on_instance(
                                 handle,
@@ -1654,7 +1718,7 @@ pub fn pieces_to_instanced_images<'a, B: InstancedOutputBuilder<'a>>(
                         filter: None,
                         color,
                     };
-                    let handle = try_insert_bitmap(bitmap.clone());
+                    let handle = try_insert_bitmap(builder, bitmap.clone());
                     builder.on_instance(
                         handle,
                         OutputInstanceParameters {

--- a/sbr-rasterize/src/rasterizer/sw.rs
+++ b/sbr-rasterize/src/rasterizer/sw.rs
@@ -995,9 +995,14 @@ impl Rasterizer {
         log: &LogContext,
         active_color: BGRA8,
         scene: &[SceneNode],
+        cull_rect: Rect2S,
         on_piece: &mut dyn FnMut(&mut Rasterizer, OutputPiece),
     ) -> Result<(), SceneRenderError> {
         for node in scene {
+            if !node.bounding_box().intersects(&cull_rect) {
+                continue;
+            }
+
             match node {
                 SceneNode::Bitmap(bitmap) => {
                     on_piece(self, OutputPiece::from_bitmap(bitmap.clone(), active_color));
@@ -1126,9 +1131,16 @@ impl Rasterizer {
         &mut self,
         log: &LogContext,
         scene: &Scene,
+        cull_rect: Rect2S,
         on_piece: &mut dyn FnMut(OutputPiece),
     ) -> Result<(), SceneRenderError> {
-        self.render_scene_pieces_impl(log, BGRA8::MAGENTA, &scene.0, &mut move |_r, p| on_piece(p))
+        self.render_scene_pieces_impl(
+            log,
+            BGRA8::MAGENTA,
+            &scene.0,
+            cull_rect,
+            &mut move |_r, p| on_piece(p),
+        )
     }
 
     pub fn render_scene(
@@ -1139,9 +1151,20 @@ impl Rasterizer {
     ) -> Result<(), super::SceneRenderError> {
         target.buffer.fill(Premultiplied(BGRA8::ZERO));
 
-        self.render_scene_pieces_impl(log, BGRA8::MAGENTA, &scene.0, &mut |r, piece| {
-            piece.blend_to(r, target, piece.pos)
-        })?;
+        let cull_rect = Rect2S::new(
+            Point2::ZERO,
+            Point2::new(
+                FixedS::new(target.width as i32),
+                FixedS::new(target.height as i32),
+            ),
+        );
+        self.render_scene_pieces_impl(
+            log,
+            BGRA8::MAGENTA,
+            &scene.0,
+            cull_rect,
+            &mut |r, piece| piece.blend_to(r, target, piece.pos),
+        )?;
 
         Ok(())
     }
@@ -1192,6 +1215,7 @@ impl RasterCache {
                         log,
                         active_color,
                         &scene.0,
+                        Rect2S::MAX,
                         &mut |_, piece| {
                             bbox.expand_to_rect(piece.rect());
                             pieces.push(piece);

--- a/sbr-rasterize/src/rasterizer/sw.rs
+++ b/sbr-rasterize/src/rasterizer/sw.rs
@@ -271,10 +271,6 @@ impl<'a, P> RenderTargetView<'a, P> {
         }
     }
 
-    pub fn buffer_mut(&mut self) -> &mut [P] {
-        self.buffer
-    }
-
     pub fn width(&self) -> u32 {
         self.width
     }
@@ -307,6 +303,20 @@ impl<'a, P> RenderTargetView<'a, P> {
         Some(unsafe {
             self.buffer
                 .get_unchecked_mut(y as usize * self.stride as usize + x as usize)
+        })
+    }
+
+    pub fn row(&mut self, y: i32) -> Option<&mut [P]> {
+        let y = u32::try_from(y).ok()?;
+
+        if y >= self.height {
+            return None;
+        }
+
+        let start = y as usize * self.stride as usize;
+        Some(unsafe {
+            self.buffer
+                .get_unchecked_mut(start..start + self.width as usize)
         })
     }
 }
@@ -524,12 +534,19 @@ const RASTER_CACHE_CONFIGURATION: CacheConfiguration = CacheConfiguration {
 };
 
 #[derive(PartialEq, Eq, Hash)]
+#[expect(clippy::enum_variant_names)]
 enum RasterCacheKey {
     SubsceneTexture {
         subscene: SubsceneCacheKey,
         active_color: BGRA8,
     },
     BlurTexture(Texture<'static>, I26Dot6),
+    ScaleTexture {
+        texture: Texture<'static>,
+        dst_size: Vec2<u32>,
+        src_off: Vec2<u32>,
+        src_size: Vec2<u32>,
+    },
 }
 
 enum SubsceneCacheKey {
@@ -601,6 +618,14 @@ impl CacheValue for CachedSubscenePieces {
 impl CacheValue for BlurOutput {
     fn memory_footprint(&self) -> usize {
         std::mem::size_of::<Self>() + self.texture.memory_footprint()
+    }
+}
+
+struct CachedTexture(Texture<'static>);
+
+impl CacheValue for CachedTexture {
+    fn memory_footprint(&self) -> usize {
+        std::mem::size_of::<Self>() + self.0.memory_footprint()
     }
 }
 
@@ -739,37 +764,7 @@ impl Rasterizer {
         }
     }
 
-    pub fn scale_mono_raw(
-        &self,
-        target: RenderTargetView<'_, MaybeUninit<u8>>,
-        src: &[u8],
-        src_width: u32,
-        src_height: u32,
-        src_stride: usize,
-        src_off: Vec2<i32>,
-        src_size: Vec2<i32>,
-    ) {
-        scale::scale_mono(
-            target, src, src_stride, src_width, src_height, src_off, src_size,
-        );
-    }
-
-    pub fn scale_bgra_raw(
-        &self,
-        target: RenderTargetView<'_, MaybeUninit<Premultiplied<BGRA8>>>,
-        src: &[Premultiplied<BGRA8>],
-        src_width: u32,
-        src_height: u32,
-        src_stride: usize,
-        src_off: Vec2<i32>,
-        src_size: Vec2<i32>,
-    ) {
-        scale::scale_bgra(
-            target, src, src_stride, src_width, src_height, src_off, src_size,
-        );
-    }
-
-    pub fn scale_texture(
+    fn scale_texture_uncached(
         &self,
         texture: &Texture,
         dst_size: Vec2<u32>,
@@ -804,6 +799,18 @@ impl Rasterizer {
                 })
             },
         }
+    }
+
+    pub fn scale_texture(
+        &self,
+        texture: &Texture<'static>,
+        dst_size: Vec2<u32>,
+        src_off: Vec2<u32>,
+        src_size: Vec2<u32>,
+    ) -> Texture<'static> {
+        self.cache
+            .get_or_scale_texture(texture, dst_size, src_off, src_size, self)
+            .clone()
     }
 }
 
@@ -970,7 +977,7 @@ impl OutputPiece {
         let texture = unwrap_sw_texture(&bitmap.texture);
         Self {
             pos: bitmap.pos,
-            size: Vec2::new(bitmap.texture.width(), bitmap.texture.height()),
+            size: bitmap.scaled_size,
             content: {
                 OutputPieceContent::Texture(OutputBitmap {
                     texture: texture.clone(),
@@ -1133,7 +1140,7 @@ impl Rasterizer {
         target.buffer.fill(Premultiplied(BGRA8::ZERO));
 
         self.render_scene_pieces_impl(log, BGRA8::MAGENTA, &scene.0, &mut |r, piece| {
-            piece.content.blend_to_impl(r, target, piece.pos)
+            piece.blend_to(r, target, piece.pos)
         })?;
 
         Ok(())
@@ -1154,9 +1161,7 @@ impl Rasterizer {
                 Vec2::new(bbox.width() as u32, bbox.height() as u32),
                 |mut view| {
                     for piece in pieces {
-                        piece
-                            .content
-                            .blend_to_impl(self, &mut view, piece.pos - bbox.min.to_vec());
+                        piece.blend_to(self, &mut view, piece.pos - bbox.min.to_vec());
                     }
                 },
             ),
@@ -1277,24 +1282,49 @@ impl RasterCache {
                 rasterizer.blur_texture(src, stddev.into_f32())
             })
     }
+
+    pub fn get_or_scale_texture(
+        &self,
+        texture: &Texture<'static>,
+        dst_size: Vec2<u32>,
+        src_off: Vec2<u32>,
+        src_size: Vec2<u32>,
+        rasterizer: &Rasterizer,
+    ) -> &Texture<'static> {
+        let Ok(CachedTexture(result)) = self.0.get_or_try_insert_with(
+            RasterCacheKey::ScaleTexture {
+                texture: texture.clone(),
+                dst_size,
+                src_off,
+                src_size,
+            },
+            || {
+                Ok::<_, std::convert::Infallible>(CachedTexture(
+                    rasterizer.scale_texture_uncached(texture, dst_size, src_off, src_size),
+                ))
+            },
+        );
+
+        result
+    }
 }
 
-impl OutputPieceContent {
-    fn blend_to_impl(
-        &self,
-        rasterizer: &mut Rasterizer,
-        target: &mut RenderTarget,
-        pos: Point2<i32>,
-    ) {
-        match self {
+impl OutputPiece {
+    fn blend_to(&self, rasterizer: &mut Rasterizer, target: &mut RenderTarget, pos: Point2<i32>) {
+        match &self.content {
             OutputPieceContent::Texture(image) => {
-                rasterizer.blit_texture_filtered(
-                    target,
-                    pos,
-                    &image.texture,
-                    image.filter,
-                    image.color,
-                );
+                let texture = if self.size == image.texture.size() {
+                    &image.texture
+                } else {
+                    &rasterizer.scale_texture(
+                        &image.texture,
+                        self.size,
+                        Vec2::ZERO,
+                        image.texture.size(),
+                    )
+                };
+
+                rasterizer.blit_texture_filtered(target, pos, texture, image.filter, image.color);
             }
             OutputPieceContent::Strips(OutputStrips { strips, color }) => {
                 let pre = color.premultiply();
@@ -1384,6 +1414,7 @@ pub trait InstancedOutputBuilder<'a> {
     fn on_instance(&mut self, image: Self::ImageHandle, params: OutputInstanceParameters);
 }
 
+#[derive(Debug)]
 struct ClipRectIntersection {
     dst_pos: Point2<i32>,
     min_clip: Vec2<u32>,
@@ -1442,6 +1473,7 @@ pub fn pieces_to_instanced_images<'a, B: InstancedOutputBuilder<'a>>(
     builder: &mut B,
     pieces: impl Iterator<Item = &'a OutputPiece>,
     clip_rect: Rect2<i32>,
+    rasterizer: &mut Rasterizer,
 ) {
     let mut texture_map = HashMap::<OutputBitmap<'static>, B::ImageHandle>::new();
 
@@ -1465,8 +1497,41 @@ pub fn pieces_to_instanced_images<'a, B: InstancedOutputBuilder<'a>>(
 
         match &piece.content {
             OutputPieceContent::Texture(bitmap) => {
-                let handle = try_insert_bitmap(bitmap.clone());
-                builder.on_instance(handle, OutputInstanceParameters::from(clip_intersection));
+                if piece.size == bitmap.texture.size() {
+                    let handle = try_insert_bitmap(bitmap.clone());
+                    builder.on_instance(handle, OutputInstanceParameters::from(clip_intersection));
+                } else {
+                    let mut params = OutputInstanceParameters {
+                        dst_pos: clip_intersection.dst_pos,
+                        dst_size: clip_intersection.size,
+                        src_off: Vec2::ZERO,
+                        src_size: bitmap.texture.size(),
+                    };
+
+                    let handle = if clip_intersection.min_clip != Vec2::ZERO
+                        || clip_intersection.max_clip != Vec2::ZERO
+                    {
+                        // We can't really pass through the scaling if clipped as it might
+                        // result in fractional offset/size, so we have to scale the bitmap
+                        // here if that's the case.
+                        let scaled = rasterizer.scale_texture(
+                            &bitmap.texture,
+                            piece.size,
+                            Vec2::ZERO,
+                            bitmap.texture.size(),
+                        );
+                        params.src_off = clip_intersection.min_clip;
+                        params.src_size = clip_intersection.size;
+                        try_insert_bitmap(OutputBitmap {
+                            texture: scaled,
+                            ..*bitmap
+                        })
+                    } else {
+                        try_insert_bitmap(bitmap.clone())
+                    };
+
+                    builder.on_instance(handle, params);
+                }
             }
             OutputPieceContent::Strips(strips) => {
                 for op in strips.strips.paint_iter() {

--- a/sbr-rasterize/src/scene.rs
+++ b/sbr-rasterize/src/scene.rs
@@ -216,7 +216,11 @@ impl<'a> SceneContentBuilder<'a> {
             }));
     }
 
-    pub fn filled_outline(&mut self, outline: impl Outline<f32>, color: impl Into<SceneColor>) {
+    pub fn filled_outline(
+        &mut self,
+        outline: impl IntoIterator<Item = OutlineEvent<f32>>,
+        color: impl Into<SceneColor>,
+    ) {
         let transf = Vec2::new(
             self.current_translation.x.into_f32(),
             self.current_translation.y.into_f32(),
@@ -225,7 +229,10 @@ impl<'a> SceneContentBuilder<'a> {
         self.parent
             .nodes
             .push(SceneNode::FilledOutline(FilledOutline {
-                events: outline.iter().map_points(|point| point + transf).collect(),
+                events: outline
+                    .into_iter()
+                    .map_points(|point| point + transf)
+                    .collect(),
                 color: color.into(),
             }));
     }

--- a/sbr-rasterize/src/scene.rs
+++ b/sbr-rasterize/src/scene.rs
@@ -130,11 +130,13 @@ impl<'a> SceneContentBuilder<'a> {
     pub fn bitmap(
         &mut self,
         texture: Texture,
+        scaled_size: Vec2<u32>,
         filter: Option<BitmapFilter>,
         color: impl Into<SceneColor>,
     ) {
         self.parent.nodes.push(SceneNode::Bitmap(Bitmap {
             pos: self.rounded_translation().to_point(),
+            scaled_size,
             texture,
             filter,
             color: color.into(),
@@ -237,6 +239,7 @@ impl From<BGRA8> for SceneColor {
 #[derive(Clone)]
 pub(crate) struct Bitmap {
     pub(crate) pos: Point2<i32>,
+    pub(crate) scaled_size: Vec2<u32>,
     pub(crate) texture: Texture,
     pub(crate) filter: Option<BitmapFilter>,
     pub(crate) color: SceneColor,

--- a/sbr-rasterize/src/scene.rs
+++ b/sbr-rasterize/src/scene.rs
@@ -30,6 +30,16 @@ impl Scene {
         Self(Rc::default())
     }
 
+    pub(crate) fn bounding_box(&self) -> Rect2S {
+        let mut bbox = Rect2S::NOTHING;
+
+        for node in self.0.iter() {
+            node.expand_bounding_box(&mut bbox);
+        }
+
+        bbox
+    }
+
     pub fn memory_footprint(&self) -> usize {
         std::mem::size_of::<Self>()
             + std::mem::size_of_val::<[_]>(&*self.0)
@@ -65,6 +75,53 @@ pub(crate) enum SceneNode {
     FilledOutline(FilledOutline),
     FilledRect(FilledRect),
     Subscene(Subscene),
+}
+
+impl SceneNode {
+    pub(crate) fn expand_bounding_box(&self, bbox: &mut Rect2S) {
+        match self {
+            SceneNode::Bitmap(bitmap) => bbox.expand_to_rect(Rect2S::from_min_size(
+                Point2::new(FixedS::new(bitmap.pos.x), FixedS::new(bitmap.pos.y)),
+                Vec2::new(
+                    FixedS::new(bitmap.scaled_size.x as i32),
+                    FixedS::new(bitmap.scaled_size.y as i32),
+                ),
+            )),
+            SceneNode::StrokedPolyline(polyline) => polyline
+                .polyline
+                .iter()
+                .copied()
+                .map(|p| {
+                    p + Vec2::new(
+                        I16Dot16::from_raw(polyline.pos.x.into_raw() << 10),
+                        I16Dot16::from_raw(polyline.pos.y.into_raw() << 10),
+                    )
+                })
+                .for_each(|p| {
+                    bbox.expand_to_point(Point2::new(
+                        FixedS::from_raw(p.x.into_raw() >> 10),
+                        FixedS::from_raw(p.y.into_raw() >> 10),
+                    ))
+                }),
+            SceneNode::FilledOutline(outline) => {
+                let cbox = outline.events.control_box();
+                bbox.expand_to_rect(Rect2S::new(
+                    Point2::new(cbox.min.x.into(), cbox.min.y.into()),
+                    Point2::new(cbox.max.x.into(), cbox.max.y.into()),
+                ));
+            }
+            SceneNode::FilledRect(filled_rect) => {
+                bbox.expand_to_rect(filled_rect.rect);
+            }
+            SceneNode::Subscene(subscene) => bbox.expand_to_rect(subscene.bounding_box()),
+        }
+    }
+
+    pub(crate) fn bounding_box(&self) -> Rect2S {
+        let mut result = Rect2::NOTHING;
+        self.expand_bounding_box(&mut result);
+        result
+    }
 }
 
 pub struct SceneBuilder {
@@ -297,6 +354,30 @@ pub trait ExternalSubscene {
 
     fn bounding_box(&self) -> Rect2S;
     fn rasterize(&self, rasterizer: &mut dyn Rasterizer) -> Result<(Vec2<i32>, Texture), AnyError>;
+}
+
+impl Subscene {
+    pub(crate) fn bounding_box(&self) -> Rect2S {
+        let inner_bbox = match &self.kind {
+            SubsceneKind::External(external) => external.bounding_box(),
+            SubsceneKind::Scene(scene) => scene.bounding_box(),
+        };
+
+        if inner_bbox == Rect2S::MAX || inner_bbox == Rect2S::NOTHING {
+            return inner_bbox;
+        }
+
+        match self.scene_filter {
+            Some(SceneFilter::ExtractAlpha { blur_stddev }) => {
+                let mut result = inner_bbox;
+                let expansion = blur_stddev * 3;
+                result.expand(expansion, expansion);
+                result
+            }
+            None => inner_bbox,
+        }
+        .translate(self.pos.to_vec())
+    }
 }
 
 impl StrokedPolyline {

--- a/sbr-rasterize/src/scene.rs
+++ b/sbr-rasterize/src/scene.rs
@@ -40,6 +40,16 @@ impl Scene {
         bbox
     }
 
+    pub(crate) fn is_mono(&self) -> bool {
+        for node in self.0.iter() {
+            if !node.is_mono() {
+                return false;
+            }
+        }
+
+        true
+    }
+
     pub fn memory_footprint(&self) -> usize {
         std::mem::size_of::<Self>()
             + std::mem::size_of_val::<[_]>(&*self.0)
@@ -121,6 +131,25 @@ impl SceneNode {
         let mut result = Rect2::NOTHING;
         self.expand_bounding_box(&mut result);
         result
+    }
+
+    pub(crate) fn is_mono(&self) -> bool {
+        match self {
+            SceneNode::Bitmap(bitmap) => {
+                bitmap.texture.is_mono() && bitmap.color == SceneColor::ACTIVE
+            }
+            &SceneNode::StrokedPolyline(StrokedPolyline { color, .. })
+            | &SceneNode::FilledOutline(FilledOutline { color, .. })
+            | &SceneNode::FilledRect(FilledRect { color, .. }) => color == SceneColor::ACTIVE,
+            SceneNode::Subscene(subscene) => {
+                subscene.active_color == SceneColor::ACTIVE
+                    && match (&subscene.scene_filter, &subscene.kind) {
+                        (Some(SceneFilter::ExtractAlpha { .. }), _) => true,
+                        (None, SubsceneKind::External(_)) => false,
+                        (None, SubsceneKind::Scene(scene)) => scene.is_mono(),
+                    }
+            }
+        }
     }
 }
 

--- a/sbr-rasterize/tests/sw.rs
+++ b/sbr-rasterize/tests/sw.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use log::RootLogger;
 use sbr_rasterize::{
     color::{to_straight_rgba, Premultiplied, BGRA8},
-    scene::{FixedS, Scene, SceneBuilder, SceneColor, SceneFilter, SubsceneKind},
+    scene::{FixedS, Rect2S, Scene, SceneBuilder, SceneColor, SceneFilter, SubsceneKind},
     sw::{self, InstancedOutputBuilder, OutputPiece},
 };
 use util::{
@@ -21,20 +21,21 @@ struct DrawChecker {
     /// This is the one that is actually saved as a snapshot,
     /// other draws are just checked to match this one.
     reference: Vec<Premultiplied<BGRA8>>,
-    /// Saved pieces used for running subsequent instanced draws.
+    scene: Scene,
+    /// Saved unculled pieces used for running subsequent instanced draws.
     pieces: Vec<OutputPiece>,
     scratch: Vec<Premultiplied<BGRA8>>,
 }
 
 impl DrawChecker {
-    fn check_immediate(name: &str, size: Vec2<u32>, scene: &Scene) -> Self {
+    fn check_immediate(name: &str, size: Vec2<u32>, scene: Scene) -> Self {
         let mut buffer = vec![Premultiplied(BGRA8::ZERO); (size.x * size.y) as usize];
         let mut target = sw::RenderTarget::new(&mut buffer, size.x, size.y, size.x);
 
         let logger = RootLogger::new();
         let mut rasterizer = sw::Rasterizer::new();
         rasterizer
-            .render_scene(&logger.new_ctx(), &mut target.reborrow(), scene)
+            .render_scene(&logger.new_ctx(), &mut target.reborrow(), &scene)
             .expect("failed to rasterize scene to framebuffer");
 
         let mut scratch = buffer.clone();
@@ -54,15 +55,18 @@ impl DrawChecker {
             pieces: {
                 let mut result = Vec::new();
                 rasterizer
-                    .render_scene_pieces(&logger.new_ctx(), scene, &mut |piece| result.push(piece))
+                    .render_scene_pieces(&logger.new_ctx(), &scene, Rect2S::MAX, &mut |piece| {
+                        result.push(piece)
+                    })
                     .unwrap();
                 result
             },
+            scene,
             rasterizer,
         }
     }
 
-    fn check_defaults(name: &str, size: Vec2<u32>, scene: &Scene) -> Self {
+    fn check_defaults(name: &str, size: Vec2<u32>, scene: Scene) -> Self {
         let mut checker = Self::check_immediate(name, size, scene);
         checker.check_instanced(
             Rect2::from_min_size(Point2::ZERO, Vec2::new(size.x as i32, size.y as i32)),
@@ -112,7 +116,12 @@ impl<'i, 't> InstancedOutputBuilder<'i> for InstanceCompositor<'t> {
 }
 
 impl DrawChecker {
-    fn check_instanced(&mut self, clip_rect: Rect2<i32>, force_snapshot: bool) {
+    fn check_instanced_culled(
+        &mut self,
+        clip_rect: Rect2<i32>,
+        cull_rect: Rect2S,
+        force_snapshot: bool,
+    ) {
         assert!(!clip_rect.is_empty());
 
         self.secondary_draw_index += 1;
@@ -124,13 +133,28 @@ impl DrawChecker {
         let mut target =
             sw::RenderTarget::new(&mut self.scratch, self.size.x, self.size.y, self.size.x);
 
+        let mut culled_pieces = Vec::new();
+        let pieces = if cull_rect == Rect2S::MAX {
+            &self.pieces
+        } else {
+            self.rasterizer
+                .render_scene_pieces(
+                    &RootLogger::new().new_ctx(),
+                    &self.scene,
+                    cull_rect,
+                    &mut |piece| culled_pieces.push(piece),
+                )
+                .unwrap();
+            &culled_pieces
+        };
+
         sw::pieces_to_instanced_images(
             &mut InstanceCompositor {
                 rasterizer: sw::Rasterizer::new(),
                 target: target.reborrow(),
                 images: Vec::new(),
             },
-            self.pieces.iter(),
+            pieces.iter(),
             clip_rect,
             &mut self.rasterizer,
         );
@@ -171,6 +195,8 @@ impl DrawChecker {
                 "Draw {} snapshot written to {display_path}",
                 self.secondary_draw_index
             );
+            eprintln!("Clip rect: {clip_rect:?}");
+            eprintln!("Cull rect: {cull_rect:?}");
         };
 
         if let Some(mismatch_position) = mismatch_position {
@@ -182,6 +208,18 @@ impl DrawChecker {
         } else if force_snapshot {
             write_snapshot();
         }
+    }
+
+    fn check_instanced(&mut self, clip_rect: Rect2<i32>, force_snapshot: bool) {
+        self.check_instanced_culled(clip_rect, Rect2S::MAX, force_snapshot);
+        self.check_instanced_culled(
+            clip_rect,
+            Rect2::new(
+                Point2::new(FixedS::new(clip_rect.min.x), FixedS::new(clip_rect.min.y)),
+                Point2::new(FixedS::new(clip_rect.max.x), FixedS::new(clip_rect.max.y)),
+            ),
+            force_snapshot,
+        );
     }
 }
 
@@ -221,7 +259,7 @@ fn simple_rectangles() {
         builder.finish()
     };
 
-    DrawChecker::check_defaults("simple_rectangles", Vec2::new(100, 100), &scene);
+    DrawChecker::check_defaults("simple_rectangles", Vec2::new(100, 100), scene);
 }
 
 #[test]
@@ -240,7 +278,7 @@ fn clipped_polyline() {
     );
     let scene = builder.finish();
 
-    let mut checker = DrawChecker::check_defaults("clipped_polyline", Vec2::new(100, 100), &scene);
+    let mut checker = DrawChecker::check_defaults("clipped_polyline", Vec2::new(100, 100), scene);
     checker.check_instanced(
         Rect2::new(Point2::new(20, -10), Point2::new(200, 80)),
         false,
@@ -307,7 +345,7 @@ fn translated_subscene_with_polyline() {
     let mut checker = DrawChecker::check_immediate(
         "translated_subscene_with_polyline",
         Vec2::new(100, 100),
-        &scene,
+        scene,
     );
     checker.check_instanced(Rect2::new(Point2::new(20, 43), Point2::new(91, 76)), false);
     checker.check_instanced(Rect2::new(Point2::new(37, 37), Point2::new(75, 89)), false);
@@ -328,7 +366,7 @@ fn antialiased_rectangle() {
     };
 
     let mut checker =
-        DrawChecker::check_immediate("antialiased_rectangle", Vec2::new(10, 10), &scene);
+        DrawChecker::check_immediate("antialiased_rectangle", Vec2::new(10, 10), scene);
     checker.check_instanced(Rect2::new(Point2::new(2, 2), Point2::new(8, 8)), false);
     checker.check_instanced(Rect2::new(Point2::new(1, 3), Point2::new(5, 6)), false);
     checker.check_instanced(Rect2::new(Point2::new(0, 0), Point2::new(5, 10)), false);
@@ -380,7 +418,7 @@ fn blurred_triangle() {
         builder.finish()
     };
 
-    _ = DrawChecker::check_defaults("blurred_triangle", Vec2::new(130, 130), &scene);
+    DrawChecker::check_defaults("blurred_triangle", Vec2::new(130, 130), scene);
 }
 
 #[test]
@@ -425,7 +463,7 @@ fn bilinear_scaling() {
         builder.finish()
     };
 
-    _ = DrawChecker::check_defaults("bilinear_scaling", scene_size, &scene);
+    DrawChecker::check_defaults("bilinear_scaling", scene_size, scene);
 }
 
 #[test]
@@ -466,7 +504,7 @@ fn placeholder_subscene_with_filled_outline() {
     let mut checker = DrawChecker::check_immediate(
         "placeholder_subscene_with_filled_outline",
         Vec2::new(60, 124),
-        &scene,
+        scene,
     );
     checker.check_instanced(Rect2::new(Point2::new(0, 15), Point2::new(60, 76)), false);
     checker.check_instanced(Rect2::new(Point2::new(37, 37), Point2::new(75, 89)), false);

--- a/sbr-rasterize/tests/sw.rs
+++ b/sbr-rasterize/tests/sw.rs
@@ -12,6 +12,7 @@ use util::{
 };
 
 struct DrawChecker {
+    rasterizer: sw::Rasterizer,
     base_path: PathBuf,
     display_base_path: String,
     secondary_draw_index: u32,
@@ -57,6 +58,7 @@ impl DrawChecker {
                     .unwrap();
                 result
             },
+            rasterizer,
         }
     }
 
@@ -130,6 +132,7 @@ impl DrawChecker {
             },
             self.pieces.iter(),
             clip_rect,
+            &mut self.rasterizer,
         );
 
         let min_x = u32::try_from(clip_rect.min.x).unwrap_or(0).min(self.size.x);
@@ -394,7 +397,6 @@ fn bilinear_scaling() {
     let r = sw::Rasterizer::new();
     let t = sw::Texture::new_borrowed_mono(RECTANGLE_TEXTURE_DATA, 5, 5);
 
-    let full_to_16 = r.scale_texture(&t, Vec2::splat(16), Vec2::ZERO, t.size());
     let part_off = Vec2::new(2, 1);
     let part_to_16 = r.scale_texture(&t, Vec2::splat(16), part_off, t.size() - part_off);
 
@@ -415,11 +417,11 @@ fn bilinear_scaling() {
             BGRA8::BLACK,
         );
         root.with_translation(Vec2::new(FixedS::new(2), FixedS::new(7)))
-            .bitmap(t.into(), None, BGRA8::WHITE);
+            .bitmap(t.clone().into(), t.size(), None, BGRA8::WHITE);
         root.with_translation(Vec2::new(FixedS::new(10), FixedS::new(2)))
-            .bitmap(full_to_16.into(), None, BGRA8::WHITE);
+            .bitmap(t.into(), Vec2::splat(16), None, BGRA8::WHITE);
         root.with_translation(Vec2::new(FixedS::new(30), FixedS::new(2)))
-            .bitmap(part_to_16.into(), None, BGRA8::WHITE);
+            .bitmap(part_to_16.into(), Vec2::splat(16), None, BGRA8::WHITE);
         builder.finish()
     };
 

--- a/sbr-util/src/math.rs
+++ b/sbr-util/src/math.rs
@@ -81,12 +81,14 @@ impl<N: Copy> Vec2<N> {
 }
 
 impl<N: Number + Signed> Vec2<N> {
+    #[track_caller]
     pub fn normal(self) -> Self {
         Self::new(self.y, -self.x)
     }
 }
 
 impl<N: Number> Vec2<N> {
+    #[track_caller]
     pub fn length(self) -> N
     where
         N: Sqrt,
@@ -94,6 +96,7 @@ impl<N: Number> Vec2<N> {
         (self.x * self.x + self.y * self.y).sqrt()
     }
 
+    #[track_caller]
     pub fn length_sq(self) -> N {
         self.x * self.x + self.y * self.y
     }
@@ -106,6 +109,7 @@ impl<N: Number> Vec2<N> {
     /// However there is also a useful geometric definition:
     /// u⋅v = ||u|| * ||v|| * cos(θ)
     /// where θ is the angle between u and v.
+    #[track_caller]
     pub fn dot(self, other: Self) -> N {
         self.x * other.x + self.y * other.y
     }
@@ -125,6 +129,7 @@ impl<N: Number> Vec2<N> {
     /// it is in the "counter-clockwise direction".
     ///
     /// another NOTE: This terminology is made up and probably not very formal.
+    #[track_caller]
     pub fn cross(self, other: Self) -> N {
         self.x * other.y - self.y * other.x
     }
@@ -148,6 +153,7 @@ impl<N: Debug> Debug for Vec2<N> {
 impl<N: Number> Mul<N> for Vec2<N> {
     type Output = Self;
 
+    #[track_caller]
     fn mul(self, rhs: N) -> Self::Output {
         Self {
             x: self.x * rhs,
@@ -159,6 +165,7 @@ impl<N: Number> Mul<N> for Vec2<N> {
 impl<N: Number> Div<N> for Vec2<N> {
     type Output = Self;
 
+    #[track_caller]
     fn div(self, rhs: N) -> Self::Output {
         Self {
             x: self.x / rhs,
@@ -223,6 +230,7 @@ impl_binop!(
 impl<N: Number + Signed> Neg for Vec2<N> {
     type Output = Self;
 
+    #[track_caller]
     fn neg(self) -> Self::Output {
         Self::new(-self.x, -self.y)
     }
@@ -280,6 +288,7 @@ impl<N: Number> Rect2<N> {
         }
     }
 
+    #[track_caller]
     pub fn translate<U>(self, vector: Vec2<U>) -> Self
     where
         U: Number,

--- a/sbr-util/src/math/outline.rs
+++ b/sbr-util/src/math/outline.rs
@@ -141,6 +141,15 @@ impl<N: Number> Outline<N> for StaticOutline<N> {
     }
 }
 
+impl<'a, N: Number> IntoIterator for &'a StaticOutline<N> {
+    type Item = OutlineEvent<N>;
+    type IntoIter = std::iter::Copied<std::slice::Iter<'a, OutlineEvent<N>>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self._events.iter().copied()
+    }
+}
+
 #[macro_export]
 macro_rules! make_static_outline {
     {

--- a/src/capi/renderer/instanced.rs
+++ b/src/capi/renderer/instanced.rs
@@ -62,7 +62,7 @@ unsafe extern "C" fn sbr_renderer_render_instanced(
 
         ctry!(renderer
             .inner
-            .render_to_scene(log, &*ctx, t, &renderer.rasterizer));
+            .render_to_scene(log, &*ctx, t, &mut renderer.rasterizer));
 
         ctry!(renderer
             .rasterizer
@@ -76,8 +76,6 @@ unsafe extern "C" fn sbr_renderer_render_instanced(
             // Make sure piece buffer is cleared if rendering fails
             // so the above assertion is not triggered in such a case.
             .inspect_err(|_| renderer.output_pieces.clear()));
-
-        renderer.rasterizer.advance_cache_generation();
 
         struct CInstancedOutputBuilder<'a, 'o> {
             images: &'o mut Vec<COutputImage<'static>>,
@@ -123,7 +121,10 @@ unsafe extern "C" fn sbr_renderer_render_instanced(
             },
             renderer.output_pieces.iter(),
             clip_rect,
+            &mut renderer.rasterizer,
         );
+
+        renderer.rasterizer.advance_cache_generation();
 
         if !renderer.output_instances.is_empty() {
             let len = renderer.output_instances.len();

--- a/src/capi/renderer/instanced.rs
+++ b/src/capi/renderer/instanced.rs
@@ -5,6 +5,7 @@ use std::{
 
 use rasterize::{
     color::{Premultiplied, BGRA8},
+    scene::{FixedS, Rect2S},
     sw::{InstancedOutputBuilder, OutputImage, OutputPiece},
 };
 use util::math::{Point2, Rect2, Vec2};
@@ -64,9 +65,13 @@ unsafe extern "C" fn sbr_renderer_render_instanced(
             .inner
             .render_to_scene(log, &*ctx, t, &mut renderer.rasterizer));
 
+        let cull_rect = Rect2S::new(
+            Point2::new(FixedS::new(clip_rect.min.x), FixedS::new(clip_rect.min.y)),
+            Point2::new(FixedS::new(clip_rect.max.x), FixedS::new(clip_rect.max.y)),
+        );
         ctry!(renderer
             .rasterizer
-            .render_scene_pieces(log, renderer.inner.scene(), &mut |piece| {
+            .render_scene_pieces(log, renderer.inner.scene(), cull_rect, &mut |piece| {
                 if piece.size.x == 0 || piece.size.y == 0 {
                     return;
                 }

--- a/src/capi/renderer/instanced.rs
+++ b/src/capi/renderer/instanced.rs
@@ -3,6 +3,7 @@ use std::{
     marker::PhantomData,
 };
 
+use log::trace;
 use rasterize::{
     color::{Premultiplied, BGRA8},
     scene::{FixedS, Rect2S},
@@ -130,6 +131,13 @@ unsafe extern "C" fn sbr_renderer_render_instanced(
         );
 
         renderer.rasterizer.advance_cache_generation();
+
+        trace!(
+            log,
+            "Rasterized to {} images and {} instances",
+            renderer.output_images.len(),
+            renderer.output_instances.len()
+        );
 
         if !renderer.output_instances.is_empty() {
             let len = renderer.output_instances.len();

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,6 +1,7 @@
 use rasterize::{
     color::BGRA8,
     scene::{SceneContentBuilder, SceneFilter},
+    Rasterizer,
 };
 use util::math::{I26Dot6, Point2, Rect2};
 
@@ -21,6 +22,7 @@ pub struct DisplayPass<'r> {
     pub output: SceneContentBuilder<'r>,
     dpi: u32,
     glyph_cache: &'r GlyphCache,
+    rasterizer: &'r mut dyn Rasterizer,
     decoration_tracker: DecorationTracker,
 }
 
@@ -30,6 +32,7 @@ struct DisplayContext<'c> {
     output: SceneContentBuilder<'c>,
     dpi: u32,
     glyph_cache: &'c GlyphCache,
+    rasterizer: &'c mut dyn Rasterizer,
     decoration_ctx: DecorationContext<'c>,
 }
 
@@ -39,11 +42,17 @@ fn round_y(mut p: Point2L) -> Point2L {
 }
 
 impl<'r> DisplayPass<'r> {
-    pub fn new(output: SceneContentBuilder<'r>, dpi: u32, glyph_cache: &'r GlyphCache) -> Self {
+    pub fn new(
+        output: SceneContentBuilder<'r>,
+        dpi: u32,
+        glyph_cache: &'r GlyphCache,
+        rasterizer: &'r mut dyn Rasterizer,
+    ) -> Self {
         Self {
             output,
             dpi,
             glyph_cache,
+            rasterizer,
             decoration_tracker: DecorationTracker::new(),
         }
     }
@@ -53,6 +62,7 @@ impl<'r> DisplayPass<'r> {
             output: self.output.child(),
             dpi: self.dpi,
             glyph_cache: self.glyph_cache,
+            rasterizer: self.rasterizer,
             decoration_ctx: self.decoration_tracker.root(),
         }
     }
@@ -93,6 +103,7 @@ impl DisplayContext<'_> {
             }),
             color,
             self.glyph_cache,
+            self.rasterizer,
         )?;
 
         Ok(())
@@ -203,6 +214,7 @@ impl DisplayContext<'_> {
             output: self.output.child(),
             dpi: self.dpi,
             glyph_cache: self.glyph_cache,
+            rasterizer: self.rasterizer,
             decoration_ctx: self
                 .decoration_ctx
                 .push_decorations(style, font_metrics_if_inline),
@@ -214,6 +226,7 @@ impl DisplayContext<'_> {
             output: self.output.child(),
             dpi: self.dpi,
             glyph_cache: self.glyph_cache,
+            rasterizer: self.rasterizer,
             decoration_ctx: self.decoration_ctx.suspend_active(),
         }
     }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -588,7 +588,7 @@ impl Renderer {
         log: &LogContext,
         ctx: &SubtitleContext,
         t: u32,
-        rasterizer: &dyn Rasterizer,
+        rasterizer: &mut dyn Rasterizer,
     ) -> Result<(), RenderError> {
         self.previous_context = *ctx;
 
@@ -659,7 +659,12 @@ impl Renderer {
 
         {
             self.scene_builder.reset();
-            let mut pass = DisplayPass::new(self.scene_builder.root(), ctx.dpi, &self.glyph_cache);
+            let mut pass = DisplayPass::new(
+                self.scene_builder.root(),
+                ctx.dpi,
+                &self.glyph_cache,
+                rasterizer,
+            );
 
             for &(pos, ref fragment) in &fragments {
                 pass.display_block_container_fragment(pos, fragment)?;

--- a/src/text.rs
+++ b/src/text.rs
@@ -3,6 +3,7 @@ use std::fmt::{Debug, Display};
 use rasterize::{
     color::BGRA8,
     scene::{SceneContentBuilder, SceneFilter},
+    Rasterizer,
 };
 use text_sys::*;
 use util::math::{I26Dot6, Vec2};
@@ -166,6 +167,7 @@ pub fn display<'g>(
     scene_filter: Option<SceneFilter>,
     color: BGRA8,
     cache: &GlyphCache,
+    rasterizer: &mut dyn Rasterizer,
 ) -> Result<(), GlyphDisplayError> {
     for (font, glyph) in glyphs {
         let offset = Vec2::new(glyph.x_offset, -glyph.y_offset);
@@ -174,7 +176,7 @@ pub fn display<'g>(
         output
             .with_translation(offset)
             .try_subscene(scene_filter, color, |subpixel_pos| {
-                font.glyph_subscene(cache, glyph.index, subpixel_pos.x, false)
+                font.glyph_subscene(cache, glyph.index, subpixel_pos.x, false, rasterizer)
                     .map(|x| x.0.clone())
             })?;
 

--- a/src/text/face.rs
+++ b/src/text/face.rs
@@ -1,6 +1,9 @@
 use std::{fmt::Debug, hash::Hash, ops::RangeInclusive, path::Path};
 
-use rasterize::scene::{FixedS, Scene, SubsceneKind, Vec2S};
+use rasterize::{
+    scene::{FixedS, Scene, SubsceneKind, Vec2S},
+    Rasterizer,
+};
 use text_sys::hb_font_t;
 use util::{
     cache::CacheValue,
@@ -128,6 +131,7 @@ trait FontImpl: Sized {
         &self,
         index: u32,
         subpixel_offset: Vec2S,
+        rasterizer: &mut dyn Rasterizer,
     ) -> Result<GlyphSubscene, Self::DisplayError>;
 }
 
@@ -255,6 +259,7 @@ impl Font {
         glyph: u32,
         offset_value: FixedS,
         offset_axis_is_y: bool,
+        rasterizer: &mut dyn Rasterizer,
     ) -> Result<&'c GlyphSubscene, GlyphDisplayError> {
         let (render_offset, subpixel_bucket) =
             FontSizeCacheKey::get_subpixel_bucket(offset_value, offset_axis_is_y);
@@ -263,8 +268,10 @@ impl Font {
             .for_glyph(self.face(), glyph, subpixel_bucket);
 
         cache.get_or_try_insert_with(key, || match self {
-            Self::FreeType(font) => font.glyph_subscene_uncached(glyph, render_offset),
-            Self::Tofu(font) => Ok(font.glyph_subscene_uncached(glyph, render_offset).unwrap()),
+            Self::FreeType(font) => font.glyph_subscene_uncached(glyph, render_offset, rasterizer),
+            Self::Tofu(font) => Ok(font
+                .glyph_subscene_uncached(glyph, render_offset, rasterizer)
+                .unwrap()),
         })
     }
 }

--- a/src/text/face/freetype.rs
+++ b/src/text/face/freetype.rs
@@ -8,8 +8,8 @@ use std::{
 };
 
 use rasterize::{
-    color::{Premultiplied, BGRA8},
-    scene::{ExternalSubscene, FixedS, Point2S, Rect2S, SubsceneKind, Vec2S},
+    color::BGRA8,
+    scene::{ExternalSubscene, FixedS, Rect2S, SceneBuilder, SubsceneKind, Vec2S},
     PixelFormat, Rasterizer, Texture,
 };
 use text_sys::*;
@@ -645,7 +645,17 @@ impl Drop for Font {
 }
 
 #[derive(Debug, Error)]
+pub enum BitmapCopyError {
+    #[error("Unsupported pixel mode {0}")]
+    UnsupportedPixelMode(std::ffi::c_uchar),
+    #[error("Unsupported (negative) bitmap pitch {0}")]
+    NegativePitch(std::ffi::c_int),
+}
+
+#[derive(Debug, Error)]
 pub enum GlyphDisplayError {
+    #[error(transparent)]
+    BitmapGlyphCopy(#[from] BitmapCopyError),
     #[error(transparent)]
     FreeType(#[from] FreeTypeError),
 }
@@ -656,10 +666,8 @@ pub enum GlyphRenderError {
     FreeType(#[from] FreeTypeError),
     #[error("Unsupported glyph format {0} after conversion")]
     ConversionToBitmapFailed(FT_Glyph_Format),
-    #[error("Unsupported pixel mode {0}")]
-    UnsupportedBitmapFormat(std::ffi::c_uchar),
-    #[error("Unsupported (negative) bitmap pitch {0}")]
-    NegativePitch(std::ffi::c_int),
+    #[error(transparent)]
+    BitmapCopy(#[from] BitmapCopyError),
 }
 
 impl FontImpl for Font {
@@ -698,11 +706,16 @@ impl FontImpl for Font {
         )
     }
 
+    // TODO: This mechanism could be improved to:
+    //       - Avoid hinting outlines for each subpixel offset
+    //         (transform is applied after hinting anyway)
+    //       - Avoid copying bitmap glyph to texture for each size separately
     type DisplayError = GlyphDisplayError;
     fn glyph_subscene_uncached(
         &self,
         index: u32,
         subpixel_offset: Vec2S,
+        rasterizer: &mut dyn Rasterizer,
     ) -> Result<GlyphSubscene, Self::DisplayError> {
         unsafe {
             let face = self.with_applied_size()?;
@@ -711,11 +724,10 @@ impl FontImpl for Font {
             fttry!(FT_Load_Glyph(
                 face,
                 index,
-                (FT_LOAD_TARGET_LIGHT | FT_LOAD_COLOR | FT_LOAD_BITMAP_METRICS_ONLY) as i32
+                (FT_LOAD_TARGET_LIGHT | FT_LOAD_COLOR) as i32
             ))?;
 
             let mut bbox;
-            let bitmap_scale;
             let glyph = (*face).glyph;
             let mut graphics = None;
             if (*glyph).format == FT_GLYPH_FORMAT_BITMAP {
@@ -725,50 +737,55 @@ impl FontImpl for Font {
                 };
 
                 let scale = self.size.bitmap_scale;
-                let total_width =
-                    (scale * ((*glyph).bitmap_left + bitmap.width as i32)).ceil_to_inner();
-                let total_height =
-                    (scale * (bitmap.width as i32 - (*glyph).bitmap_top)).ceil_to_inner();
-
-                bbox = Rect2S::from_min_size(
-                    Point2S::ZERO,
-                    Vec2::new(FixedS::new(total_width), FixedS::new(total_height)),
+                let scaled_offset = {
+                    Vec2::new(
+                        scale * ((*glyph).bitmap_left),
+                        scale * (-(*glyph).bitmap_top),
+                    )
+                };
+                let scaled_size = Vec2::new(
+                    (scale * bitmap.width as i32).floor_to_inner() as u32,
+                    (scale * bitmap.rows as i32).floor_to_inner() as u32,
                 );
-                bitmap_scale = self.size.bitmap_scale;
-            } else {
-                bitmap_scale = I26Dot6::ONE;
-                if (*glyph).format == FT_GLYPH_FORMAT_OUTLINE
-                    // HACK: COLRv0 glyphs have OUTLINE format but are handled specially by
-                    // FreeType and when we do our funny caching we get a SIGSEGV.
-                    // Correct solution is not misusing the API in this way but I want to minimize
-                    // the amount of `FT_Render_Glyph` reimplemented here so for now let's just
-                    // avoid caching outlines from fonts that have color layers.
-                    && ((*face).face_flags & FT_FACE_FLAG_COLOR as FT_Long) == 0
-                {
-                    let outline = FTOutline::from_ref(&(*glyph).outline);
-                    if outline.points().is_empty() {
-                        return Ok(GlyphSubscene::empty());
-                    }
+                let texture = copy_glyph_slot_bitmap_to_texture(glyph, rasterizer)?;
 
-                    bbox = Rect2S::NOTHING;
-                    for p in outline.points() {
-                        bbox.expand_to_point(Point2::new(
-                            FixedS::from_ft(p.x),
-                            FixedS::from_ft(-p.y),
-                        ));
-                    }
-
-                    graphics = Some(CachedGlyphGraphics::Outline(OwnedFTOutline::from(outline)))
-                } else {
-                    bbox = Rect2S::MAX;
+                return Ok(GlyphSubscene(SubsceneKind::Scene({
+                    let mut b = SceneBuilder::new();
+                    b.root().with_translation(scaled_offset).bitmap(
+                        texture,
+                        scaled_size,
+                        None,
+                        BGRA8::WHITE,
+                    );
+                    b.finish()
+                })));
+            } else if (*glyph).format == FT_GLYPH_FORMAT_OUTLINE
+                // HACK: COLRv0 glyphs have OUTLINE format but are handled specially by
+                // FreeType and when we do our funny caching we get a SIGSEGV.
+                // Correct solution is not misusing the API in this way but I want to minimize
+                // the amount of `FT_Render_Glyph` reimplemented here so for now let's just
+                // avoid caching outlines from fonts that have color layers.
+                && ((*face).face_flags & FT_FACE_FLAG_COLOR as FT_Long) == 0
+            {
+                let outline = FTOutline::from_ref(&(*glyph).outline);
+                if outline.points().is_empty() {
+                    return Ok(GlyphSubscene::empty());
                 }
+
+                bbox = Rect2S::NOTHING;
+                for p in outline.points() {
+                    bbox.expand_to_point(Point2::new(FixedS::from_ft(p.x), FixedS::from_ft(-p.y)));
+                }
+
+                graphics = Some(CachedGlyphGraphics::Outline(OwnedFTOutline::from(outline)))
+            } else {
+                bbox = Rect2S::MAX;
             }
 
             let subscene = Rc::new(FreeTypeSubscene {
                 font: self.clone(),
                 index,
                 subpixel_offset,
-                bitmap_scale,
                 graphics,
                 bbox,
             });
@@ -776,6 +793,44 @@ impl FontImpl for Font {
             Ok(GlyphSubscene(SubsceneKind::External(subscene)))
         }
     }
+}
+
+unsafe fn copy_glyph_slot_bitmap_to_texture(
+    glyph: FT_GlyphSlot,
+    rasterizer: &mut dyn Rasterizer,
+) -> Result<Texture, BitmapCopyError> {
+    let glyph = &*glyph;
+
+    let Ok(src_stride) = usize::try_from(glyph.bitmap.pitch) else {
+        // I have never seen this and have no idea how it works.
+        // Better to error out than do garbage memory access and likely crash.
+        return Err(BitmapCopyError::NegativePitch(glyph.bitmap.pitch));
+    };
+
+    let pixel_format = match glyph.bitmap.pixel_mode.into() {
+        FT_PIXEL_MODE_GRAY => PixelFormat::Mono,
+        FT_PIXEL_MODE_BGRA => PixelFormat::Bgra,
+        _ => {
+            return Err(BitmapCopyError::UnsupportedPixelMode(
+                glyph.bitmap.pixel_mode,
+            ))
+        }
+    };
+
+    Ok(rasterizer.create_texture_mapped(
+        Vec2::new(glyph.bitmap.width, glyph.bitmap.rows),
+        pixel_format,
+        Box::new(|mut target| {
+            let mut ptr = glyph.bitmap.buffer;
+            let src_width = usize::from(pixel_format.width()) * glyph.bitmap.width as usize;
+
+            for y in 0..glyph.bitmap.rows {
+                let row = std::slice::from_raw_parts(ptr.cast(), src_width);
+                target.row(y as i32).unwrap().copy_from_slice(row);
+                ptr = ptr.add(src_stride);
+            }
+        }),
+    ))
 }
 
 struct TransformGuard(FT_Face);
@@ -824,7 +879,6 @@ struct FreeTypeSubscene {
     font: Font,
     index: u32,
     subpixel_offset: Vec2S,
-    bitmap_scale: I26Dot6,
     graphics: Option<CachedGlyphGraphics>,
     bbox: Rect2S,
 }
@@ -946,101 +1000,10 @@ impl FreeTypeSubscene {
             return Ok((Vec2::ZERO, rasterizer.empty_mono_texture()));
         };
 
-        // I have never seen this and have no idea how it works.
-        // Better to error out than do garbage memory access and likely crash.
-        if bitmap.pitch < 0 {
-            return Err(GlyphRenderError::NegativePitch(bitmap.pitch));
-        }
-
-        enum PixelMode {
-            Mono8,
-            Bgra8,
-        }
-
-        let pixel_mode = match bitmap.pixel_mode.into() {
-            FT_PIXEL_MODE_GRAY => PixelMode::Mono8,
-            FT_PIXEL_MODE_BGRA => PixelMode::Bgra8,
-            _ => return Err(GlyphRenderError::UnsupportedBitmapFormat(bitmap.pixel_mode)),
-        };
-
-        let scaled_offset = unsafe {
-            Vec2::new(
-                (self.bitmap_scale * (*glyph).bitmap_left).round_to_inner(),
-                (self.bitmap_scale * -(*glyph).bitmap_top).round_to_inner(),
-            )
-        };
-        let dst_size = Vec2::new(
-            (bitmap.width * self.bitmap_scale.into_raw() as u32) >> 6,
-            (bitmap.rows * self.bitmap_scale.into_raw() as u32) >> 6,
-        );
-
-        let texture = unsafe {
-            rasterizer.create_texture_mapped(
-                dst_size,
-                if matches!(pixel_mode, PixelMode::Bgra8) {
-                    PixelFormat::Bgra
-                } else {
-                    PixelFormat::Mono
-                },
-                Box::new(|mut target| {
-                    let mut src_stride = bitmap.pitch.unsigned_abs() as usize;
-                    let src_width = bitmap.width;
-                    let src_height = bitmap.rows;
-                    let src_off = Vec2::ZERO;
-                    let src_size = Vec2::new(src_width as i32, src_height as i32);
-                    let src = std::slice::from_raw_parts(
-                        bitmap.buffer.cast_const(),
-                        src_stride * src_height as usize,
-                    );
-
-                    let sw = rasterize::sw::Rasterizer::new();
-                    match pixel_mode {
-                        PixelMode::Mono8 => {
-                            sw.scale_mono_raw(
-                                target, src, src_width, src_height, src_stride, src_off, src_size,
-                            );
-                        }
-                        PixelMode::Bgra8 => {
-                            assert!(
-                                bitmap.buffer.cast::<BGRA8>().is_aligned(),
-                                "FreeType gave us an unaligned BGRA8 bitmap"
-                            );
-                            assert!(
-                                src_stride % 4 == 0,
-                                "FreeType gave us a BGRA8 bitmap with an unaligned stride"
-                            );
-                            src_stride /= 4;
-
-                            let width = target.width() / 4;
-                            let height = target.height();
-                            let stride = target.stride() / 4;
-                            let target = rasterize::sw::RenderTargetView::new(
-                                std::slice::from_raw_parts_mut(
-                                    target
-                                        .buffer_mut()
-                                        .as_mut_ptr()
-                                        .cast::<MaybeUninit<Premultiplied<BGRA8>>>(),
-                                    height as usize * stride as usize,
-                                ),
-                                width,
-                                height,
-                                stride,
-                            );
-                            let src = std::slice::from_raw_parts(
-                                src.as_ptr().cast::<Premultiplied<BGRA8>>(),
-                                src.len() / 4,
-                            );
-
-                            sw.scale_bgra_raw(
-                                target, src, src_width, src_height, src_stride, src_off, src_size,
-                            );
-                        }
-                    };
-                }),
-            )
-        };
-
-        Ok((scaled_offset, texture))
+        Ok((
+            unsafe { Vec2::new((*glyph).bitmap_left, -(*glyph).bitmap_top) },
+            unsafe { copy_glyph_slot_bitmap_to_texture(glyph, rasterizer)? },
+        ))
     }
 }
 

--- a/src/text/face/freetype.rs
+++ b/src/text/face/freetype.rs
@@ -9,13 +9,13 @@ use std::{
 
 use rasterize::{
     color::BGRA8,
-    scene::{ExternalSubscene, FixedS, Rect2S, SceneBuilder, SubsceneKind, Vec2S},
+    scene::{ExternalSubscene, FixedS, Rect2S, SceneBuilder, SceneColor, SubsceneKind, Vec2S},
     PixelFormat, Rasterizer, Texture,
 };
 use text_sys::*;
 use thiserror::Error;
 use util::{
-    math::{I16Dot16, I26Dot6, Point2, Vec2},
+    math::{I16Dot16, I26Dot6, Outline, OutlineEvent, Point2, Vec2},
     AnyError,
 };
 
@@ -777,6 +777,20 @@ impl FontImpl for Font {
                     bbox.expand_to_point(Point2::new(FixedS::from_ft(p.x), FixedS::from_ft(-p.y)));
                 }
 
+                let bbox_size = bbox.size();
+                let bbox_min_dim = bbox_size.x.min(bbox_size.y);
+                let bbox_max_dim = bbox_size.x.max(bbox_size.y);
+                if bbox_max_dim > 128 && bbox_min_dim > 64 {
+                    let mut b = SceneBuilder::new();
+                    b.root().filled_outline(
+                        outline
+                            .iter()
+                            .map(|x| x.map(|c| Point2::new(c.x.into_f32(), -c.y.into_f32()))),
+                        SceneColor::ACTIVE,
+                    );
+                    return Ok(GlyphSubscene(SubsceneKind::Scene(b.finish())));
+                }
+
                 graphics = Some(CachedGlyphGraphics::Outline(OwnedFTOutline::from(outline)))
             } else {
                 bbox = Rect2S::MAX;
@@ -918,6 +932,148 @@ impl FTOutline {
 
     unsafe fn from_ref(outline: &FT_Outline) -> &FTOutline {
         std::mem::transmute(outline)
+    }
+}
+
+impl util::math::Outline<I26Dot6> for FTOutline {
+    fn iter(&self) -> impl Iterator<Item = OutlineEvent<I26Dot6>> {
+        const CURVE_TAG_ON: u8 = 1;
+        const CURVE_TAG_CONIC: u8 = 0;
+        const CURVE_TAG_CUBIC: u8 = 2;
+
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        #[repr(u8)]
+        enum DegreeTag {
+            On = CURVE_TAG_ON,
+            Conic = CURVE_TAG_CONIC,
+            Cubic = CURVE_TAG_CUBIC,
+        }
+
+        impl DegreeTag {
+            fn from_value(value: u8) -> Option<Self> {
+                match value & 0b11 {
+                    CURVE_TAG_ON => Some(Self::On),
+                    CURVE_TAG_CONIC => Some(Self::Conic),
+                    CURVE_TAG_CUBIC => Some(Self::Cubic),
+                    _ => None,
+                }
+            }
+        }
+
+        fn to_point(ft: FT_Vector) -> Point2<I26Dot6> {
+            Point2::new(I26Dot6::from_ft(ft.x), I26Dot6::from_ft(ft.y))
+        }
+
+        #[derive(Debug, Clone)]
+        struct PointsAndTags<'a>(
+            std::iter::Zip<std::slice::Iter<'a, FT_Vector>, std::slice::Iter<'a, u8>>,
+        );
+
+        impl Iterator for PointsAndTags<'_> {
+            type Item = (Point2<I26Dot6>, DegreeTag);
+
+            fn next(&mut self) -> Option<Self::Item> {
+                self.0.next().map(|(&p, &t)| {
+                    (
+                        to_point(p),
+                        DegreeTag::from_value(t).expect("Invalid FreeType tag degree"),
+                    )
+                })
+            }
+        }
+
+        struct OutlineEventsIter<'a> {
+            outline: &'a FTOutline,
+            first: usize,
+            contours: std::slice::Iter<'a, u16>,
+
+            first_point: Point2<I26Dot6>,
+            closed: bool,
+            current: PointsAndTags<'a>,
+        }
+
+        impl Iterator for OutlineEventsIter<'_> {
+            type Item = OutlineEvent<I26Dot6>;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                if let Some((point, tag)) = self.current.next() {
+                    let mut peek_or_close_with_first =
+                        |iter: &PointsAndTags| match iter.clone().next() {
+                            Some(v) => v,
+                            None => {
+                                self.closed = true;
+                                (self.first_point, DegreeTag::On)
+                            }
+                        };
+
+                    return if tag == DegreeTag::On {
+                        Some(OutlineEvent::LineTo(point))
+                    } else if tag == DegreeTag::Conic {
+                        let (np, ntag) = peek_or_close_with_first(&self.current);
+                        let end = if ntag == DegreeTag::Conic {
+                            point.midpoint(np)
+                        } else {
+                            assert_eq!(ntag, DegreeTag::On);
+                            _ = self.current.next();
+                            np
+                        };
+                        Some(OutlineEvent::QuadTo(point, end))
+                    } else if tag == DegreeTag::Cubic {
+                        let (c1, c1tag) = self.current.next().unwrap();
+                        assert_eq!(c1tag, DegreeTag::Cubic);
+                        let (end, endtag) = peek_or_close_with_first(&self.current);
+                        assert_eq!(endtag, DegreeTag::On);
+                        Some(OutlineEvent::CubicTo(point, c1, end))
+                    } else {
+                        unreachable!()
+                    };
+                } else if !self.closed {
+                    self.closed = true;
+                    return Some(OutlineEvent::LineTo(self.first_point));
+                }
+
+                let last = match self.contours.next() {
+                    Some(&x) => usize::from(x),
+                    None => {
+                        assert_eq!(self.first, self.outline.points().len());
+                        return None;
+                    }
+                };
+                let points = self.outline.points();
+                let tags = self.outline.tags();
+
+                let mut add_range = self.first..last + 1;
+                if (tags[self.first] & 0b11) != CURVE_TAG_ON {
+                    if (tags[last] & 0b11) == CURVE_TAG_CONIC {
+                        self.first_point =
+                            to_point(points[self.first]).midpoint(to_point(points[last]));
+                    } else {
+                        assert_eq!(tags[last] & 0b11, CURVE_TAG_ON);
+                        self.first_point = to_point(points[last]);
+                        add_range.end -= 1;
+                    }
+                } else {
+                    self.first_point = to_point(points[self.first]);
+                    add_range.start += 1;
+                };
+
+                self.first = last + 1;
+                self.current =
+                    PointsAndTags(std::iter::zip(&points[add_range.clone()], &tags[add_range]));
+                self.closed = false;
+
+                Some(OutlineEvent::MoveTo(self.first_point))
+            }
+        }
+
+        OutlineEventsIter {
+            outline: self,
+            first: 0,
+            contours: self.contours().iter(),
+            first_point: Point2::ZERO,
+            closed: true,
+            current: PointsAndTags(std::iter::zip(&[], &[])),
+        }
     }
 }
 

--- a/src/text/face/tofu.rs
+++ b/src/text/face/tofu.rs
@@ -389,7 +389,7 @@ impl Font {
             }
         }
 
-        output.filled_outline(&*outline, SceneColor::ACTIVE);
+        output.filled_outline(outline.iter().copied(), SceneColor::ACTIVE);
     }
 }
 

--- a/src/text/face/tofu.rs
+++ b/src/text/face/tofu.rs
@@ -425,6 +425,7 @@ impl FontImpl for Font {
         &self,
         index: u32,
         subpixel_offset: rasterize::scene::Vec2S,
+        _rasterizer: &mut dyn rasterize::Rasterizer,
     ) -> Result<GlyphSubscene, Self::DisplayError> {
         let mut builder = SceneBuilder::new();
         self.build_glyph_outline(builder.root().with_translation(subpixel_offset), index);

--- a/tests/layout/common.rs
+++ b/tests/layout/common.rs
@@ -253,7 +253,12 @@ fn check_fn(
     name: &str,
     viewport_size: Vec2L,
     dpi: u32,
-    fun: impl FnOnce(&mut LayoutContext, &LayoutConstraints, &mut SceneBuilder),
+    fun: impl FnOnce(
+        &mut LayoutContext,
+        &LayoutConstraints,
+        &mut SceneBuilder,
+        &mut dyn rasterize::Rasterizer,
+    ),
 ) {
     let project_dir = test_util::project_dir();
     let tests_dir = project_dir.join("tests/");
@@ -272,6 +277,7 @@ fn check_fn(
     let height = viewport_size.y.ceil_to_inner() as u32;
     let mut pixels = {
         let mut scene_builder = SceneBuilder::new();
+        let mut rasterizer = rasterize::sw::Rasterizer::new();
         fun(
             &mut LayoutContext {
                 log,
@@ -282,10 +288,10 @@ fn check_fn(
                 size: viewport_size,
             },
             &mut scene_builder,
+            &mut rasterizer,
         );
 
         let mut pixels = vec![Premultiplied(BGRA8::ZERO); width as usize * height as usize];
-        let mut rasterizer = rasterize::sw::Rasterizer::new();
         let mut render_target = rasterize::sw::RenderTarget::new(&mut pixels, width, height, width);
 
         rasterizer
@@ -312,14 +318,19 @@ pub fn check_inline(
     dpi: u32,
     inline: InlineContent,
 ) {
-    check_fn(name, viewport_size, dpi, |lctx, constraints, output| {
-        let fragment =
-            layout::inline::layout(lctx, constraints, &inline).expect("Inline layout failed");
+    check_fn(
+        name,
+        viewport_size,
+        dpi,
+        |lctx, constraints, output, rasterizer| {
+            let fragment =
+                layout::inline::layout(lctx, constraints, &inline).expect("Inline layout failed");
 
-        DisplayPass::new(output.root(), dpi, &GlyphCache::new())
-            .display_inline_content_fragment(pos, &fragment)
-            .expect("Display failed");
-    })
+            DisplayPass::new(output.root(), dpi, &GlyphCache::new(), rasterizer)
+                .display_inline_content_fragment(pos, &fragment)
+                .expect("Display failed");
+        },
+    )
 }
 
 pub fn check_block(
@@ -329,13 +340,18 @@ pub fn check_block(
     dpi: u32,
     block: BlockContainer,
 ) {
-    check_fn(name, viewport_size, dpi, |lctx, constraints, output| {
-        let fragment = layout::block::layout(lctx, constraints, &block).expect("Layout failed");
+    check_fn(
+        name,
+        viewport_size,
+        dpi,
+        |lctx, constraints, output, rasterizer| {
+            let fragment = layout::block::layout(lctx, constraints, &block).expect("Layout failed");
 
-        DisplayPass::new(output.root(), dpi, &GlyphCache::new())
-            .display_block_container_fragment(pos, &fragment)
-            .expect("Display failed");
-    })
+            DisplayPass::new(output.root(), dpi, &GlyphCache::new(), rasterizer)
+                .display_block_container_fragment(pos, &fragment)
+                .expect("Display failed");
+        },
+    )
 }
 
 macro_rules! check_one {


### PR DESCRIPTION
https://fishhh.dev/up/u1ElAi.mp4 <2ms per frame.

Also delays scaling of bitmap glyphs.

Two things:
- Blur still absolutely decimates all our hopes and dreams. Zooming in in mpv causes our blur to reach σ>80 with textures consisting of hundreds of thousands of pixels. I'm not sure how to handle this, likely we'll have to find a way to *approximate harder* for such extreme σs. The huge texture is also hard to avoid, maybe we could get away with blurring only a subimage for such huge cases but the texture is still going to be at most viewport sized (unless we clamp it even lower and then billinear scale it as approximation?).
- Yes, there are subrandr components that arguably need optimization more.

TODO:
- [x] Make rasterizer tests test passing different cull rects