### PR TITLE
Some cleanup

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,9 +27,7 @@
         ];
       in
       with pkgs.lib; {
-        packages.default = pkgs.callPackage
-          (import ./nix/default.nix self.shortRev or self.dirtyShortRev)
-          { };
+        packages.default = pkgs.callPackage (import ./nix/default.nix) { buildRevision = self.shortRev or self.dirtyShortRev; };
         devShell = pkgs.mkShell {
           nativeBuildInputs = with pkgs; [
             bashInteractive

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,11 +1,10 @@
-buildRevision:
 { rustPlatform
 , stdenv
 , pkg-config
-, jq
 , harfbuzz
 , freetype
 , fontconfig
+, buildRevision ? null
 , ...
 }:
 
@@ -23,7 +22,6 @@ rustPlatform.buildRustPackage {
 
   nativeBuildInputs = [
     pkg-config
-    jq
   ];
 
   buildInputs = [

--- a/sbr-rasterize/src/rasterizer/sw.rs
+++ b/sbr-rasterize/src/rasterizer/sw.rs
@@ -1077,24 +1077,20 @@ impl Rasterizer {
                     on_piece(self, OutputPiece::from_bitmap(bitmap.clone(), active_color));
                 }
                 &SceneNode::FilledRect(FilledRect { rect, color }) => {
+                    let floored_pos =
+                        Point2::new(rect.min.x.floor_to_inner(), rect.min.y.floor_to_inner());
                     on_piece(
                         self,
                         OutputPiece {
-                            pos: Point2::new(
-                                rect.min.x.floor_to_inner(),
-                                rect.min.y.floor_to_inner(),
-                            ),
+                            pos: floored_pos,
                             size: Vec2::new(
-                                (rect.max.x - rect.min.x.floor()).ceil_to_inner() as u32,
-                                (rect.max.y - rect.min.y.floor()).ceil_to_inner() as u32,
+                                (rect.max.x - floored_pos.x).ceil_to_inner() as u32,
+                                (rect.max.y - floored_pos.y).ceil_to_inner() as u32,
                             ),
                             content: OutputPieceContent::Rect(OutputRect {
                                 rect: Rect2S {
-                                    min: Point2::new(rect.min.x.fract(), rect.min.y.fract()),
-                                    max: Point2::new(
-                                        rect.max.x - rect.min.x.floor(),
-                                        rect.max.y - rect.min.y.floor(),
-                                    ),
+                                    min: rect.min - floored_pos.to_vec(),
+                                    max: rect.max - floored_pos.to_vec(),
                                 },
                                 color: color.compute(active_color),
                             }),

--- a/sbr-rasterize/src/scene.rs
+++ b/sbr-rasterize/src/scene.rs
@@ -417,6 +417,8 @@ impl Subscene {
 }
 
 impl StrokedPolyline {
+    // TODO: Get rid of this. The rounding here is probably wrong anyway...
+    //       Part of "finally figure out a sane outline repr" goal.
     pub fn to_strips(
         &self,
         strip_rasterizer: &mut sw::StripRasterizer,
@@ -424,8 +426,6 @@ impl StrokedPolyline {
         let mut bbox = Rect2::bounding_box_of_points(self.polyline.iter().copied());
         bbox.expand(self.width, self.width);
 
-        // TODO: I've implemented this or similar logic like 10 times
-        //       already can we split this out into a function please??
         let pos16 = Point2::new(
             I16Dot16::from_raw(self.pos.x.into_raw() << 10),
             I16Dot16::from_raw(self.pos.y.into_raw() << 10),

--- a/sbr-util/src/math/fixed.rs
+++ b/sbr-util/src/math/fixed.rs
@@ -268,6 +268,8 @@ macro_rules! define_fixed_for_type {
                 Self(signed_floor + Self::ONE.0 * (was_negative_with_fract as $type))
             }
 
+            // TODO: Most callsites of this are using it when they shouldn't or don't need to.
+            //       Fix them?
             pub const fn fract(self) -> Self {
                 let unsigned = self.0 & Self::FRACTIONAL_MASK;
                 let mut extension = (self.0 & Self::SIGN_MASK) >> (<$type>::BITS - P - 1);

--- a/src/html/entities.rs
+++ b/src/html/entities.rs
@@ -53,7 +53,7 @@ struct NextSparsePair {
 #[repr(C, align(2))]
 struct Aligned16<const N: usize>([u8; N]);
 
-const TRIE_DATA: Aligned16<53040> = Aligned16(*include_bytes!("./trie_little_endian.bin"));
+static TRIE_DATA: Aligned16<53040> = Aligned16(*include_bytes!("./trie_little_endian.bin"));
 
 unsafe fn traverse(ptr: *const u8, remaining: &[u8]) -> Option<(&'static str, u8)> {
     unsafe {

--- a/src/layout/inline/glyph_string.rs
+++ b/src/layout/inline/glyph_string.rs
@@ -493,12 +493,12 @@ mod test {
     use util::math::I26Dot6;
 
     use super::GlyphString;
-    use crate::text::{Direction, Face, Glyph};
+    use crate::text::{Direction, Font, Glyph};
 
     #[test]
     fn split_off_in_glyph() {
         let original = {
-            let font = Face::tofu().with_size(I26Dot6::new(16), 72).unwrap();
+            let font = Font::tofu(I26Dot6::new(16), 72);
             let mut result = GlyphString::new(Rc::from("abcde"), Direction::Ltr);
             result.segments.extend([
                 super::GlyphStringSegment {

--- a/src/text/face.rs
+++ b/src/text/face.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Debug, hash::Hash, ops::RangeInclusive, path::Path};
 
 use rasterize::{
-    scene::{FixedS, Scene, SubsceneKind, Vec2S},
+    scene::{FixedS, Scene, SubsceneKind},
     Rasterizer,
 };
 use text_sys::hb_font_t;
@@ -83,27 +83,6 @@ impl FontMetrics {
     }
 }
 
-trait FaceImpl: Sized {
-    type Font: FontImpl<Face = Self>;
-
-    fn family_name(&self) -> &str;
-    fn addr(&self) -> usize;
-
-    fn axes(&self) -> &[Axis];
-    fn axis(&self, tag: OpenTypeTag) -> Option<Axis> {
-        self.axes().iter().find(|x| x.tag == tag).copied()
-    }
-    fn set_axis(&mut self, index: usize, value: I16Dot16);
-
-    fn weight(&self) -> I16Dot16;
-    fn italic(&self) -> bool;
-
-    fn contains_codepoint(&self, codepoint: u32) -> bool;
-
-    type Error;
-    fn with_size(&self, point_size: I26Dot6, dpi: u32) -> Result<Self::Font, Self::Error>;
-}
-
 #[derive(Clone)]
 pub struct GlyphSubscene(pub SubsceneKind);
 
@@ -111,28 +90,6 @@ impl GlyphSubscene {
     fn empty() -> Self {
         Self(SubsceneKind::Scene(Scene::empty()))
     }
-}
-
-trait FontImpl: Sized {
-    type Face;
-    fn face(&self) -> &Self::Face;
-
-    fn metrics(&self) -> &FontMetrics;
-    fn point_size(&self) -> I26Dot6;
-    // Used to fix HarfBuzz metrics for scaled bitmap fonts which HarfBuzz sees in
-    // their unscaled form. It would be ideal to instead handle this in
-    // the font funcs but that's non-trivial so this works.
-    fn harfbuzz_scale_factor_for(&self, glyph: u32) -> I26Dot6;
-
-    fn size_cache_key(&self) -> FontSizeCacheKey;
-
-    type DisplayError;
-    fn glyph_subscene_uncached(
-        &self,
-        index: u32,
-        subpixel_offset: Vec2S,
-        rasterizer: &mut dyn Rasterizer,
-    ) -> Result<GlyphSubscene, Self::DisplayError>;
 }
 
 macro_rules! forward_methods {
@@ -188,16 +145,11 @@ impl Face {
         freetype::Face::load_from_static_bytes(bytes, index).map(Face::FreeType)
     }
 
-    pub const fn tofu() -> Self {
-        Face::Tofu(tofu::Face)
-    }
-
     forward_methods!(
         variants = Face::[FreeType, Tofu];
         pub fn family_name[&]() -> &str;
 
         pub fn axes[&]() -> &[Axis];
-        pub fn axis[&](tag: OpenTypeTag) -> Option<Axis>;
         pub fn set_axis[&mut](index: usize, value: I16Dot16) -> ();
 
         pub fn weight[&]() -> I16Dot16;
@@ -206,19 +158,25 @@ impl Face {
         pub fn contains_codepoint[&](codepoint: u32) -> bool;
     );
 
+    pub fn axis(&self, tag: OpenTypeTag) -> Option<Axis> {
+        self.axes().iter().find(|x| x.tag == tag).copied()
+    }
+
     pub fn addr(&self) -> usize {
         match self {
             Face::FreeType(face) => face.addr(),
-            Face::Tofu(face) => face.addr(),
+            Face::Tofu(tofu::Face) => {
+                // This is an unaligned address that should never occur
+                // in any actually real font backends.
+                1
+            }
         }
     }
 
     pub fn with_size(&self, point_size: I26Dot6, dpi: u32) -> Result<Font, FreeTypeError> {
         match &self {
             Face::FreeType(face) => face.with_size(point_size, dpi).map(Font::FreeType),
-            Face::Tofu(face) => match face.with_size(point_size, dpi) {
-                Ok(font) => Ok(Font::Tofu(font)),
-            },
+            Face::Tofu(tofu::Face) => Ok(Font::Tofu(tofu::Font::create(point_size, dpi))),
         }
     }
 }
@@ -239,10 +197,14 @@ impl Font {
         pub fn harfbuzz_scale_factor_for[&](glyph: u32) -> I26Dot6;
     );
 
+    pub fn tofu(point_size: I26Dot6, dpi: u32) -> Self {
+        Self::Tofu(tofu::Font::create(point_size, dpi))
+    }
+
     pub fn face(&self) -> Face {
         match self {
             Font::FreeType(font) => Face::FreeType(font.face().clone()),
-            Font::Tofu(_) => Face::tofu(),
+            Font::Tofu(_) => Face::Tofu(tofu::Face),
         }
     }
 
@@ -269,9 +231,7 @@ impl Font {
 
         cache.get_or_try_insert_with(key, || match self {
             Self::FreeType(font) => font.glyph_subscene_uncached(glyph, render_offset, rasterizer),
-            Self::Tofu(font) => Ok(font
-                .glyph_subscene_uncached(glyph, render_offset, rasterizer)
-                .unwrap()),
+            Self::Tofu(font) => Ok(font.glyph_subscene_uncached(glyph, render_offset, rasterizer)),
         })
     }
 }

--- a/src/text/face/freetype.rs
+++ b/src/text/face/freetype.rs
@@ -19,7 +19,7 @@ use util::{
     AnyError,
 };
 
-use super::{Axis, FaceImpl, FontImpl, FontMetrics, OpenTypeTag};
+use super::{Axis, FontMetrics, OpenTypeTag};
 use crate::text::{ft_utils::*, FontSizeCacheKey, GlyphSubscene};
 
 // Light hinting is used to ensure horizontal metrics remain unchanged by hinting.
@@ -210,28 +210,26 @@ impl Face {
     }
 }
 
-impl FaceImpl for Face {
-    type Font = Font;
-
-    fn family_name(&self) -> &str {
+impl Face {
+    pub(super) fn family_name(&self) -> &str {
         // NOTE: FreeType says this is *always* an ASCII string.
         unsafe { CStr::from_ptr((*self.face).family_name).to_str().unwrap() }
     }
 
-    fn addr(&self) -> usize {
+    pub(super) fn addr(&self) -> usize {
         self.face.addr()
     }
 
-    fn axes(&self) -> &[Axis] {
+    pub(super) fn axes(&self) -> &[Axis] {
         &self.shared_data().axes
     }
 
-    fn set_axis(&mut self, index: usize, value: I16Dot16) {
+    pub(super) fn set_axis(&mut self, index: usize, value: I16Dot16) {
         assert!(self.shared_data().axes[index].is_value_in_range(value));
         self.coords[index] = value.into_ft();
     }
 
-    fn weight(&self) -> I16Dot16 {
+    pub(super) fn weight(&self) -> I16Dot16 {
         SharedFaceData::get_ref(self.face)
             .axes
             .iter()
@@ -252,7 +250,7 @@ impl FaceImpl for Face {
             )
     }
 
-    fn italic(&self) -> bool {
+    pub(super) fn italic(&self) -> bool {
         SharedFaceData::get_ref(self.face)
             .axes
             .iter()
@@ -263,7 +261,7 @@ impl FaceImpl for Face {
             )
     }
 
-    fn contains_codepoint(&self, codepoint: u32) -> bool {
+    pub(super) fn contains_codepoint(&self, codepoint: u32) -> bool {
         if unsafe { FT_Select_Charmap(self.face, FT_ENCODING_UNICODE) } != 0 {
             return false;
         }
@@ -274,8 +272,7 @@ impl FaceImpl for Face {
         index != 0
     }
 
-    type Error = FreeTypeError;
-    fn with_size(&self, point_size: I26Dot6, dpi: u32) -> Result<Font, FreeTypeError> {
+    pub(super) fn with_size(&self, point_size: I26Dot6, dpi: u32) -> Result<Font, FreeTypeError> {
         Font::create(self.face, self.coords, point_size, dpi)
     }
 }
@@ -670,25 +667,23 @@ pub enum GlyphRenderError {
     BitmapCopy(#[from] BitmapCopyError),
 }
 
-impl FontImpl for Font {
-    type Face = Face;
-
-    fn face(&self) -> &Self::Face {
+impl Font {
+    pub(super) fn face(&self) -> &Face {
         unsafe { std::mem::transmute(self) }
     }
 
-    fn metrics(&self) -> &FontMetrics {
+    pub(super) fn metrics(&self) -> &FontMetrics {
         &self.size.metrics
     }
 
-    fn point_size(&self) -> I26Dot6 {
+    pub(super) fn point_size(&self) -> I26Dot6 {
         self.size.point_size
     }
 
     // FIXME: This is not really correct since it should also scale bitmaps in scalable
     //        fonts but doing that with FreeType is a pain. Since fonts rarely mix
     //        outlines and bitmaps let's just ignore that for now.
-    fn harfbuzz_scale_factor_for(&self, _glyph: u32) -> I26Dot6 {
+    pub(super) fn harfbuzz_scale_factor_for(&self, _glyph: u32) -> I26Dot6 {
         let is_scalable =
             unsafe { (*self.ft_face).face_flags & (FT_FACE_FLAG_SCALABLE as FT_Long) != 0 };
         if is_scalable {
@@ -698,7 +693,7 @@ impl FontImpl for Font {
         }
     }
 
-    fn size_cache_key(&self) -> FontSizeCacheKey {
+    pub(super) fn size_cache_key(&self) -> FontSizeCacheKey {
         FontSizeCacheKey::new(
             self.point_size(),
             self.size.dpi,
@@ -710,13 +705,12 @@ impl FontImpl for Font {
     //       - Avoid hinting outlines for each subpixel offset
     //         (transform is applied after hinting anyway)
     //       - Avoid copying bitmap glyph to texture for each size separately
-    type DisplayError = GlyphDisplayError;
-    fn glyph_subscene_uncached(
+    pub(super) fn glyph_subscene_uncached(
         &self,
         index: u32,
         subpixel_offset: Vec2S,
         rasterizer: &mut dyn Rasterizer,
-    ) -> Result<GlyphSubscene, Self::DisplayError> {
+    ) -> Result<GlyphSubscene, GlyphDisplayError> {
         unsafe {
             let face = self.with_applied_size()?;
             let _guard = TransformGuard::new(face, subpixel_offset);

--- a/src/text/face/tofu.rs
+++ b/src/text/face/tofu.rs
@@ -1,4 +1,4 @@
-use std::{convert::Infallible, ffi::c_void};
+use std::ffi::c_void;
 
 use rasterize::scene::{SceneBuilder, SceneColor, SceneContentBuilder, SubsceneKind};
 use text_sys::*;
@@ -7,7 +7,7 @@ use util::{
     math::{I16Dot16, I26Dot6, Outline, OutlineIterExt as _, Point2, Rect2, StaticOutline, Vec2},
 };
 
-use super::{FaceImpl, FontImpl, FontMetrics, GlyphMetrics};
+use super::{FontMetrics, GlyphMetrics};
 use crate::{
     layout::{FixedL, Vec2L},
     text::{FontSizeCacheKey, GlyphSubscene},
@@ -16,42 +16,29 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Face;
 
-impl FaceImpl for Face {
-    type Font = Font;
-
-    fn family_name(&self) -> &str {
+impl Face {
+    pub(super) fn family_name(&self) -> &str {
         "Subrandr Tofu Font"
     }
 
-    fn addr(&self) -> usize {
-        // This is an unaligned address that should never occur
-        // in any actually real font backends.
-        1
-    }
-
-    fn axes(&self) -> &[super::Axis] {
+    pub(super) fn axes(&self) -> &[super::Axis] {
         &[]
     }
 
-    fn set_axis(&mut self, _index: usize, _value: I16Dot16) {
+    pub(super) fn set_axis(&mut self, _index: usize, _value: I16Dot16) {
         panic!("Cannot set builtin tofu font axis values")
     }
 
-    fn weight(&self) -> I16Dot16 {
+    pub(super) fn weight(&self) -> I16Dot16 {
         I16Dot16::new(400)
     }
 
-    fn italic(&self) -> bool {
+    pub(super) fn italic(&self) -> bool {
         false
     }
 
-    fn contains_codepoint(&self, _codepoint: u32) -> bool {
+    pub(super) fn contains_codepoint(&self, _codepoint: u32) -> bool {
         true
-    }
-
-    type Error = Infallible;
-    fn with_size(&self, point_size: I26Dot6, dpi: u32) -> Result<Self::Font, Self::Error> {
-        Ok(Font::create(point_size, dpi))
     }
 }
 
@@ -391,28 +378,20 @@ impl Font {
 
         output.filled_outline(outline.iter().copied(), SceneColor::ACTIVE);
     }
-}
 
-impl FontImpl for Font {
-    type Face = Face;
-
-    fn face(&self) -> &Self::Face {
-        &Face
-    }
-
-    fn metrics(&self) -> &FontMetrics {
+    pub(super) fn metrics(&self) -> &FontMetrics {
         &self.shared().font_metrics
     }
 
-    fn point_size(&self) -> I26Dot6 {
+    pub(super) fn point_size(&self) -> I26Dot6 {
         self.shared().point_size
     }
 
-    fn harfbuzz_scale_factor_for(&self, _glyph: u32) -> I26Dot6 {
+    pub(super) fn harfbuzz_scale_factor_for(&self, _glyph: u32) -> I26Dot6 {
         I26Dot6::ONE
     }
 
-    fn size_cache_key(&self) -> FontSizeCacheKey {
+    pub(super) fn size_cache_key(&self) -> FontSizeCacheKey {
         FontSizeCacheKey::new(
             self.point_size(),
             self.shared().dpi,
@@ -420,16 +399,15 @@ impl FontImpl for Font {
         )
     }
 
-    type DisplayError = Infallible;
-    fn glyph_subscene_uncached(
+    pub(super) fn glyph_subscene_uncached(
         &self,
         index: u32,
         subpixel_offset: rasterize::scene::Vec2S,
         _rasterizer: &mut dyn rasterize::Rasterizer,
-    ) -> Result<GlyphSubscene, Self::DisplayError> {
+    ) -> GlyphSubscene {
         let mut builder = SceneBuilder::new();
         self.build_glyph_outline(builder.root().with_translation(subpixel_offset), index);
-        Ok(GlyphSubscene(SubsceneKind::Scene(builder.finish())))
+        GlyphSubscene(SubsceneKind::Scene(builder.finish()))
     }
 }
 

--- a/src/text/font_match.rs
+++ b/src/text/font_match.rs
@@ -158,7 +158,7 @@ impl FontMatcher {
     }
 
     pub fn tofu(&self) -> Font {
-        Face::tofu().with_size(self.size, self.dpi).unwrap()
+        Font::tofu(self.size, self.dpi)
     }
 
     pub fn size(&self) -> I26Dot6 {


### PR DESCRIPTION
No idea why I decided to make these `FaceImpl`/`FontImpl` traits. They are useless, get rid of them.

Surprised myself when I found out that the nix derivation depends on `jq` for no reason.

New clippy lint provides useful feedback (❤️ clippy).

`StrokedPolyline` is only there because our outline repr is imperfect, complain about this instead of fixing it.

At some point in the past I thought `.fract()` was a reasonable primitive for computing these fractional rounding/offset things, but that does not, in fact, make sense. It would make sense if our definition of `.fract()` was `skrifa`-incorrect (`x - x.floor()`) however that's not what `.fract()` is, what `.fract()` is is not useful here. It's not really useful in other places either as most places that use it *correctly* call it on strictly non-negative values, others use it incorrectly or don't really need `.fract()`.