### PR TITLE
Release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 ## [Unreleased]
 
-- Fixed infinite recursion when failing to shape an RTL segment if font provider fallback returns a font for the first codepoint.
-- The experimental `wgpu` rasterizer has been removed. Hardware acceleration may be revisited in the future with a revised approach.
+## [v1.4.0]
+
+- Fixed infinite recursion when failing to shape an RTL segment if font fallback returns a font for its first codepoint.
+- Removed experimental `wgpu` rasterizer. Hardware acceleration may be revisited in the future with a revised approach.
 - Fixed glyph y-offset being applied incorrectly. This fixes some glyphs in complex scripts like Arabic being misplaced on the y-axis.
-- WebVTT subtitles now correctly use `white-space-collapse: preserve-breaks` instead of `white-space-collapse: preserve`.
+- Made WebVTT subtitles correctly use `white-space-collapse: preserve-breaks` instead of `white-space-collapse: preserve`.
+- Added early culling to software rasterizer to skip rasterization of offscreen glyphs.
+- Made FreeType glyph rendering switch to internal sparse outline rasterizer for large outline glyphs.
+- Moved FreeType bitmap glyph scaling into rasterizer (out of FreeType font backend).
+- Made software rasterizer defer scaling of unclipped bitmaps to user in instanced mode.
 
 ## [v1.3.0]
 
@@ -83,7 +89,8 @@
 - Fixed pixel scale handling in font matching. After the introduction of the new inline layout engine fonts were being unintentionally scaled *twice* on DPIs other than 72.
 - Added Android NDK font provider for better font matching on Android.
 
-[Unreleased]: https://github.com/afishhh/subrandr/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/afishhh/subrandr/compare/v1.4.0...HEAD
+[v1.4.0]: https://github.com/afishhh/subrandr/compare/v1.3.0...v1.4.0
 [v1.3.0]: https://github.com/afishhh/subrandr/compare/v1.2.0...v1.3.0
 [v1.2.0]: https://github.com/afishhh/subrandr/compare/v1.1.0...v1.2.0
 [v1.1.0]: https://github.com/afishhh/subrandr/compare/v1.0.1...v1.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,11 +1357,11 @@ dependencies = [
 
 [[package]]
 name = "sbr-log"
-version = "0.6.0"
+version = "0.7.0"
 
 [[package]]
 name = "sbr-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1370,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "sbr-overlay"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "sbr-rasterize"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "sbr-log",
  "sbr-test-util",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "sbr-test-util"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "png",
  "sha2",
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "sbr-util"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "hashbrown",
 ]
@@ -1518,7 +1518,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subrandr"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "icu_locale",
  "icu_segmenter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "subrandr"
-version = "1.3.0"
+version = "1.4.0"
 edition.workspace = true
 autotests = false
 rust-version.workspace = true
 
 [workspace.package]
 # Version number for internal packages with unstable APIs.
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.85"
 


### PR DESCRIPTION
Initially was going to just release a v1.3.1 with the infinite recursion and y-offset fixes but there isn't really anything that'd be blocking a release right now so it should be fine to just make a whole new minor release.

I haven't found any issues with the new rasterizer improvements and the performance improvement in the happy case is so huge that I don't want to be withholding it from anyone not following master.