### PR TITLE
Fix trailing semicolon in expression from `make_static_outline` macro

### DIFF
--- a/sbr-util/src/math/outline.rs
+++ b/sbr-util/src/math/outline.rs
@@ -196,7 +196,7 @@ macro_rules! make_static_outline {
     };
     (@count_command $($anything: tt)*) => { 1 };
     (@count_close_contour($first: expr) $next: expr, $($rest: tt)*) => {
-        $crate::make_static_outline!(@count_close_contour($first) $($rest)*);
+        $crate::make_static_outline!(@count_close_contour($first) $($rest)*)
     };
     (@count_close_contour($first: expr) $last: expr) => {
         if const { $first.x != $last.x || $first.y != $last.y } { 1 } else { 0 }


### PR DESCRIPTION
This FCW was ~~recently~~ a long time ago moved to deny-by-default and breaks subrandr on Rust nightly.

I use exclusively nightly Rust when building locally but for some reason this *did not show up* as a warning before. Since this means a future Rust release will likely break existing subrandr releases, we will need a point release when that happens.