### PR TITLE
Add support for WebVTT STYLE blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 - Fixed SRV3 ruby annotations being styled by the annotation segment's pen instead of the base's pen.
+- Added basic support for WebVTT STYLE blocks.
 
 ## [v1.4.0]
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Currently subrandr is in the [User agents that do not support CSS](https://www.w
 
 The most notable limitations for this format currently are:
 - No vertical text support
-- No CSS (`STYLE` block) support
+- Incomplete CSS selector/property support
 - No region support
 
 ### Usage

--- a/sbr-log/src/lib.rs
+++ b/sbr-log/src/lib.rs
@@ -249,7 +249,6 @@ pub trait LogOnceKey: Sized + 'static {}
 
 // Allows us to use one hashset instead of many
 // hashsets for each type of event
-#[doc(hidden)]
 pub struct LogOnceSet {
     items: UnsafeCell<HashSet<(std::any::TypeId, u64)>>,
 }

--- a/src/csssyn.rs
+++ b/src/csssyn.rs
@@ -16,7 +16,6 @@ pub mod peek;
 pub mod token;
 mod tokenizer;
 
-#[cfg_attr(not(test), expect(unused_imports))]
 pub use buffer::TokenBuffer;
 pub use error::ParseError;
 pub use peek::Peek;

--- a/src/csssyn/algorithms.rs
+++ b/src/csssyn/algorithms.rs
@@ -181,6 +181,156 @@ pub fn parse_declaration_list<'a>(mut cursor: Cursor<'a>) -> impl Iterator<Item 
     })
 }
 
+pub enum BlockItem<'a> {
+    Rule(Rule<'a>),
+    Declaration(Declaration<'a>),
+}
+
+pub enum Rule<'a> {
+    Qualified(QualifiedRule<'a>),
+}
+
+pub struct QualifiedRule<'a> {
+    pub prelude: Cursor<'a>,
+    pub content: BlockContent<'a>,
+}
+
+// https://drafts.csswg.org/css-syntax-3/#consume-block-contents but this is ran on a limited cursor.
+// And returns items one-by-one instead of in chunks.
+fn parse_a_blocks_contents<'a>(mut cursor: Cursor<'a>) -> impl Iterator<Item = BlockItem<'a>> {
+    std::iter::from_fn(move || loop {
+        if cursor.eof() {
+            return None;
+        }
+
+        cursor = cursor.skip(Whitespace);
+
+        if let Some(next) = cursor.next_if(Token![;]) {
+            cursor = next;
+            continue;
+        }
+
+        // Consume a declaration from input, with nested set to true.
+        let (decl, next) = consume_a_declaration(cursor, true);
+
+        // If a declaration was returned, append it to decls, and discard a mark from input.
+        if let Some(decl) = decl {
+            cursor = next;
+            return Some(BlockItem::Declaration(decl));
+        }
+
+        // Otherwise, restore a mark from input, then consume a qualified rule from input, with nested set to true, and <semicolon-token> as the stop token.
+        let rule;
+        (rule, cursor) = consume_a_qualified_rule(cursor, true, true);
+
+        if let Some(rule) = rule {
+            return Some(BlockItem::Rule(Rule::Qualified(rule)));
+        }
+    })
+}
+
+pub struct BlockContent<'a>(Cursor<'a>);
+
+impl<'a> BlockContent<'a> {
+    pub fn parse(&self) -> impl Iterator<Item = BlockItem<'a>> {
+        parse_a_blocks_contents(self.0)
+    }
+}
+
+// https://drafts.csswg.org/css-syntax-3/#consume-a-block
+// This deviates a bit from the spec by consuming the whole group at once to
+// make things simpler but should result in the same behavior.
+fn consume_a_block<'a>(mut cursor: Cursor<'a>) -> (BlockContent<'a>, Cursor<'a>) {
+    // Assert: The next token is a <{-token>.
+    let content_start = cursor
+        .next_if(LeftBrace)
+        .expect("The next token is a <{-token>.");
+    let block_end = cursor.group_end().unwrap();
+
+    // Consume a block’s contents from input and let rules be the result.
+    let rules = BlockContent(content_start.limited(block_end));
+    cursor = block_end;
+
+    // Discard a token from input.
+    cursor = cursor.next().unwrap_or(cursor);
+
+    (rules, cursor)
+}
+
+// https://drafts.csswg.org/css-syntax-3/#consume-a-qualified-rule
+fn consume_a_qualified_rule<'a>(
+    mut cursor: Cursor<'a>,
+    nested: bool,
+    stop_on_semicolon: bool,
+) -> (Option<QualifiedRule<'a>>, Cursor<'a>) {
+    let prelude_start = cursor;
+    loop {
+        if cursor.eof() || (stop_on_semicolon && cursor.is(Token![;])) {
+            return (None, cursor);
+        }
+
+        if let Some(next) = cursor.next_if(RightBrace) {
+            if nested {
+                return (None, cursor);
+            } else {
+                cursor = next;
+            }
+        } else if let Some(next) = cursor.next_if(LeftBrace) {
+            let prelude = prelude_start.limited(cursor);
+            // If the first two non-<whitespace-token> values of rule’s prelude are an <ident-token> whose value starts with "--" followed by a <colon-token>, then:
+            if prelude
+                .skip(Whitespace)
+                .take::<Ident>()
+                .is_some_and(|(ident, next)| {
+                    ident.value().starts_with("--") && next.skip(Whitespace).is(Token![:])
+                })
+            {
+                if nested {
+                    // If nested is true, consume the remnants of a bad declaration from input, with nested set to true, and return nothing.
+                    cursor = consume_the_remnants_of_a_bad_declaration(cursor, true);
+                    return (None, cursor);
+                } else {
+                    // If nested is false, consume a block from input, and return nothing.
+                    (_, cursor) = consume_a_block(next);
+                    return (None, cursor);
+                }
+            } else {
+                let content;
+                (content, cursor) = consume_a_block(cursor);
+
+                return (Some(QualifiedRule { prelude, content }), cursor);
+            }
+        } else {
+            // Consume a component value from input and append the result to rule’s prelude.
+            cursor = skip_a_component_value(cursor);
+        }
+    }
+}
+
+// https://drafts.csswg.org/css-syntax-3/#consume-a-stylesheets-contents
+pub fn consume_a_stylesheets_contents<'a>(
+    mut cursor: Cursor<'a>,
+) -> impl Iterator<Item = Rule<'a>> {
+    std::iter::from_fn(move || loop {
+        if let Some(next) = cursor
+            .next_if(Whitespace)
+            .or(cursor.next_if(Token![<!--]))
+            .or(cursor.next_if(Token![-->]))
+        {
+            cursor = next;
+        } else if cursor.eof() {
+            return None;
+        } else {
+            let (rule, next) = consume_a_qualified_rule(cursor, false, false);
+            cursor = next;
+
+            if let Some(rule) = rule {
+                return Some(Rule::Qualified(rule));
+            }
+        }
+    })
+}
+
 #[cfg(test)]
 mod test {
     use crate::csssyn::TokenBuffer;

--- a/src/csssyn/buffer.rs
+++ b/src/csssyn/buffer.rs
@@ -6,11 +6,13 @@ use crate::csssyn::tokenizer::TokenizerError;
 
 use super::{
     token::TokenParse,
-    tokenizer::{tokenize, HashTypeFlag, TokenKind},
+    tokenizer::{tokenize, TokenKind},
     ParseError, Peek, Span, Spanned,
 };
 
 const SOURCE_LEN_LIMIT: u32 = 1 << 20;
+
+pub use super::tokenizer::HashTypeFlag;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Delimiter {
@@ -143,13 +145,13 @@ impl From<BufferTokenizationError> for ParseError {
     }
 }
 
+#[derive(Debug)]
 pub struct TokenBuffer<'a> {
     source: &'a str,
     entries: Vec<Entry>,
 }
 
 impl<'a> TokenBuffer<'a> {
-    #[cfg_attr(not(test), expect(dead_code))]
     pub fn from_source(source: &'a str) -> Result<Self, BufferTokenizationError> {
         let Some(source_end) = u32::try_from(source.len())
             .ok()
@@ -268,7 +270,6 @@ impl<'a> TokenBuffer<'a> {
         Ok(Self { source, entries })
     }
 
-    #[cfg_attr(not(test), expect(dead_code))]
     pub fn start(&self) -> Cursor<'_> {
         unsafe {
             Cursor {
@@ -323,8 +324,7 @@ impl<'a> Cursor<'a> {
         }
     }
 
-    #[cfg(test)]
-    pub(super) fn scope_source(self) -> &'a str {
+    pub fn scope_source(self) -> &'a str {
         let start_entry = self.entry();
         let end_entry = self.end().entry();
         unsafe {

--- a/src/csssyn/parse_stream.rs
+++ b/src/csssyn/parse_stream.rs
@@ -1,9 +1,8 @@
 use std::convert::Infallible;
 
 use crate::csssyn::{
-    buffer::{Cursor, TokenView},
+    buffer::Cursor,
     token::{End, FunctionalNotation, Token, TokenParse, Whitespace},
-    tokenizer::{Escaped, TokenKind},
     ParseError, Peek,
 };
 
@@ -99,32 +98,9 @@ impl<'a, T: TokenParse<'a>> Parse<'a> for T {
 
 impl<'a> Parse<'a> for FunctionalNotation<'a> {
     fn parse(stream: &mut ParseStream<'a>) -> Result<Self, ParseError> {
-        let cursor = stream.cursor();
-        let Some((
-            TokenView {
-                span,
-                source,
-                kind: TokenKind::Function,
-            },
-            next,
-        )) = cursor.token()
-        else {
-            return Err(ParseError::unexpected(cursor, &[Self::name()]));
-        };
-
-        let Some(group_end) = cursor.group_end() else {
-            return Err(ParseError::new(cursor, "unclosed functional notation"));
-        };
-
-        let inner = next.limited(group_end);
-        stream.advance_to(group_end.next().unwrap());
-
-        Ok(FunctionalNotation {
-            span,
-            function: Escaped::new(&source[..source.len() - 1]),
-
-            content: inner,
-        })
+        let (result, next) = FunctionalNotation::take(stream.cursor())?;
+        stream.advance_to(next);
+        Ok(result)
     }
 }
 

--- a/src/csssyn/token.rs
+++ b/src/csssyn/token.rs
@@ -252,15 +252,18 @@ impl<'a> Dimension<'a> {
 
 #[derive(Debug, Clone, Copy)]
 pub struct FunctionalNotation<'a> {
-    pub(super) span: Span,
-    #[expect(dead_code)]
-    pub(super) function: Escaped<'a>,
-    pub(super) content: Cursor<'a>,
+    span: Span,
+    function: Escaped<'a>,
+    content: Cursor<'a>,
 }
 
 impl_spanned!(FunctionalNotation<'_>);
 
 impl<'a> FunctionalNotation<'a> {
+    pub fn function(&self) -> Escaped<'a> {
+        self.function
+    }
+
     pub fn content(&self) -> Cursor<'a> {
         self.content
     }
@@ -282,6 +285,38 @@ impl<'a> Token for FunctionalNotation<'a> {
                 _
             ))
         )
+    }
+}
+
+impl<'a> FunctionalNotation<'a> {
+    pub fn take(cursor: Cursor<'a>) -> Result<(Self, Cursor<'a>), ParseError> {
+        let Some((
+            TokenView {
+                span,
+                source,
+                kind: TokenKind::Function,
+            },
+            next,
+        )) = cursor.token()
+        else {
+            return Err(ParseError::unexpected(cursor, &[Self::name()]));
+        };
+
+        let Some(group_end) = cursor.group_end() else {
+            return Err(ParseError::new(cursor, "unclosed functional notation"));
+        };
+
+        let inner = next.limited(group_end);
+        let end = group_end.next().unwrap();
+
+        Ok((
+            FunctionalNotation {
+                span,
+                function: Escaped::new(&source[..source.len() - 1]),
+                content: inner,
+            },
+            end,
+        ))
     }
 }
 
@@ -307,14 +342,13 @@ impl<'a> Hash<'a> {
         self.value
     }
 
-    #[expect(dead_code)]
     pub fn type_flag(&self) -> HashTypeFlag {
         self.type_flag
     }
 }
 
 macro_rules! impl_punct_tokens {
-    ($($name: ident [$($kind: tt)*] $err_name: literal $(, $macro_tt: tt)?;)*) => {
+    ($($name: ident [$($kind: tt)*] $err_name: literal $([$($macro_tt: tt)*])?;)*) => {
         $(#[doc(hidden)]
         #[derive(Clone, Copy)]
         pub struct $name {
@@ -333,21 +367,25 @@ macro_rules! impl_punct_tokens {
 
         macro_rules! TokenMacro {
             (0) => { $crate::csssyn::token::Zero };
-            $($(($macro_tt) => { $crate::csssyn::token::$name };)?)*
+            $($(($($macro_tt)*) => { $crate::csssyn::token::$name };)?)*
         }
         pub(crate) use TokenMacro as Token;
     };
 }
 
 impl_punct_tokens!(
-    Whitespace [Whitespace] "<whitespace>";
-    Comma [Punct(',')] ",", ,;
-    Colon [Punct(':')] ":", :;
-    Semicolon [Punct(';')] ";", ;;
-    ExclamationMark [Punct('!')] "!", !;
-    Slash [Punct('/')] "/", /;
-    LeftBrace [LBrace] "{";
-    RightBrace [RBrace] "}";
+    Whitespace      [Whitespace] "<whitespace>";
+    Comma           [Punct(',')] ","    [,];
+    Colon           [Punct(':')] ":"    [:];
+    Semicolon       [Punct(';')]  ";"   [;];
+    ExclamationMark [Punct('!')] "!"    [!];
+    Slash           [Punct('/')] "/"    [/];
+    Asterisk        [Punct('*')] "*"    [*];
+    Dot             [Punct('.')] "."    [.];
+    Cdo             [Cdo]        "<!--" [<!--];
+    Cdc             [Cdc]        "-->"  [-->];
+    LeftBrace       [LBrace]     "{";
+    RightBrace      [RBrace]     "}";
 );
 
 #[doc(hidden)]

--- a/src/csssyn/tokenizer.rs
+++ b/src/csssyn/tokenizer.rs
@@ -580,6 +580,12 @@ impl PartialEq<&str> for Escaped<'_> {
     }
 }
 
+impl From<Escaped<'_>> for Box<str> {
+    fn from(value: Escaped<'_>) -> Self {
+        value.unescape_iter().collect()
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HashTypeFlag {
     Id,
@@ -666,6 +672,18 @@ impl<'a> Escaped<'a> {
         self.unescape_iter()
             .map(|x| x.to_ascii_lowercase())
             .eq(string.chars().map(|x| x.to_ascii_lowercase()))
+    }
+
+    pub fn starts_with(self, string: &str) -> bool {
+        let mut u = self.unescape_iter();
+
+        for c in string.chars() {
+            if u.next() != Some(c) {
+                return false;
+            }
+        }
+
+        true
     }
 }
 

--- a/src/layout/inline/builder.rs
+++ b/src/layout/inline/builder.rs
@@ -214,7 +214,7 @@ impl<'a> InlineSpanBuilder<'a> {
         &self.parent.text_runs[self.run_index]
     }
 
-    fn style(&self) -> &ComputedStyle {
+    pub(crate) fn style(&self) -> &ComputedStyle {
         match self.parent.items.get(self.span_index) {
             Some(InlineItem::Span(span)) => &span.style,
             Some(InlineItem::Text(_) | InlineItem::Block(_) | InlineItem::SpanEnd) => {

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::LazyLock};
 
 use icu_segmenter::options::{LineBreakStrictness, LineBreakWordOption};
-use log::{warn, LogContext};
+use log::{log_once_state, warn, LogContext, LogOnceSet};
 use rasterize::color::BGRA8;
 use util::{
     math::{I16Dot16, I26Dot6},
@@ -78,14 +78,37 @@ static DECLARATION_HANDLER_MAP: LazyLock<DeclarationHandlerMap> = LazyLock::new(
     result
 });
 
-#[cfg_attr(not(all(test, feature = "_layout_tests")), expect(dead_code))]
-pub fn compute_with_declarations(
+pub struct DeclarationFilter(DeclarationHandlerMap, &'static str);
+
+impl DeclarationFilter {
+    pub fn new(allowed: impl IntoIterator<Item = &'static str>, message: &'static str) -> Self {
+        let it = allowed.into_iter();
+        let mut result = HashMap::with_capacity(it.size_hint().0);
+
+        for name in it {
+            result.insert(
+                name,
+                *DECLARATION_HANDLER_MAP.get(name).unwrap_or_else(|| {
+                    unreachable!("unknown name in declaration filter: {name:?}")
+                }),
+            );
+        }
+
+        Self(result, message)
+    }
+}
+
+pub fn apply_declarations_to(
     log: &LogContext,
+    target: ComputedStyle,
     declarations: &mut dyn Iterator<Item = &[Declaration<'_>]>,
     parent: &ComputedStyle,
+    filter: Option<&DeclarationFilter>,
+    logset: &LogOnceSet,
 ) -> ComputedStyle {
-    let mut result = parent.create_derived();
+    log_once_state!(in logset; ignoring_declaration, invalid_declaration_value);
 
+    let handler_map = filter.map_or(&*DECLARATION_HANDLER_MAP, |f| &f.0);
     let mut name_buffer = String::new();
     let mut declarations: Vec<_> = declarations
         .flatten()
@@ -98,8 +121,23 @@ pub fn compute_with_declarations(
                     .map(|x| x.to_ascii_lowercase()),
             );
 
-            let Some(handler) = DECLARATION_HANDLER_MAP.get(&*name_buffer) else {
-                warn!(log, "Ignoring unrecognized declaration for '{name_buffer}'");
+            let Some(handler) = handler_map.get(&*name_buffer) else {
+                if let Some(filter) =
+                    filter.filter(|_| DECLARATION_HANDLER_MAP.contains_key(&*name_buffer))
+                {
+                    warn!(
+                        log,
+                        once(ignoring_declaration, &name_buffer),
+                        "Ignoring declaration for '{name_buffer}': {}",
+                        filter.1
+                    );
+                } else {
+                    warn!(
+                        log,
+                        once(ignoring_declaration, &name_buffer),
+                        "Ignoring unrecognized declaration for '{name_buffer}'"
+                    );
+                }
                 return None;
             };
 
@@ -108,14 +146,37 @@ pub fn compute_with_declarations(
         .collect();
     declarations.sort_by_key(|&(_, _, important)| important);
 
+    let mut result = target;
     for (handler, value, _) in declarations {
         match (handler.parse_and_compute)(&mut result, value, parent) {
             Ok(()) => (),
             Err(error) => {
-                warn!(log, "Failed to parse '{}' value: {}", handler.name, error);
+                let error_string = error.to_string();
+                warn!(
+                    log,
+                    once(invalid_declaration_value, (handler.name, &error_string)),
+                    "Failed to parse '{}' value: {error_string}",
+                    handler.name,
+                );
             }
         }
     }
 
     result
+}
+
+#[cfg_attr(not(all(test, feature = "_layout_tests")), expect(dead_code))]
+pub fn compute_with_declarations(
+    log: &LogContext,
+    declarations: &mut dyn Iterator<Item = &[Declaration<'_>]>,
+    parent: &ComputedStyle,
+) -> ComputedStyle {
+    apply_declarations_to(
+        log,
+        parent.create_derived(),
+        declarations,
+        parent,
+        None,
+        &LogOnceSet::new(),
+    )
 }

--- a/src/vtt/convert.rs
+++ b/src/vtt/convert.rs
@@ -1,14 +1,15 @@
-use std::ops::Range;
+use std::{ops::Range, sync::LazyLock};
 
 use log::{log_once_state, warn, LogContext, LogOnceSet};
 use rasterize::color::BGRA8;
 use util::{
-    math::{I16Dot16, I26Dot6, Point2, Rect2},
+    math::{I16Dot16, Point2, Rect2},
     rc::Rc,
     rc_static,
 };
 
 use crate::{
+    csssyn::algorithms::Declaration,
     layout::{
         self,
         block::BlockContainerFragment,
@@ -17,12 +18,17 @@ use crate::{
     },
     renderer::{FrameLayoutPass, SubtitleEvent},
     style::{
+        apply_declarations_to,
         computed::{Color, FontSlant, HorizontalAlignment, WhiteSpaceCollapse},
-        ComputedStyle,
+        ComputedStyle, DeclarationFilter,
     },
     text::OpenTypeTag,
-    vtt, SubtitleContext,
+    vtt::{self, convert::stylesheet::Stylesheet},
+    SubtitleContext,
 };
+
+mod selectors;
+mod stylesheet;
 
 #[derive(Debug)]
 enum ComputedLine {
@@ -112,13 +118,59 @@ pub struct Event {
     y: f64,
 }
 
+// https://www.w3.org/TR/webvtt1/#the-cue-pseudo-element
+static WEBVTT_DECLARATION_FILTER: LazyLock<DeclarationFilter> = LazyLock::new(|| {
+    DeclarationFilter::new(
+        // Commented out values are not-yet-implemented.
+        // It is kind of ambiguous whether shorthands are supposed to be supported
+        // so not sure about those.
+        [
+            "color",
+            // "opacity",
+            // "visibility",
+            "text-decoration-line",
+            // "text-decoration-thickness",
+            // "text-decoration-style",
+            "text-decoration-color",
+            // "text-decoration",
+            "text-shadow",
+            // "background-image",
+            // "background-position",
+            // "background-size",
+            // "background-repeat",
+            // "background-origin",
+            // "background-clip",
+            // "background-attachment",
+            "background-color",
+            // "background",
+            // "outline-width",
+            // "outline-style",
+            // "outline-color",
+            // "outline",
+            "font-style",
+            // "font-variant",
+            "font-weight",
+            // "font-width",
+            "font-size",
+            // "line-height",
+            "font-family",
+            // "font",
+            // "white-space",
+            // "text-combine-upright",
+            // "ruby-position"
+        ],
+        "Not allowed in WebVTT",
+    )
+});
+
 impl Event {
     fn layout(
         &self,
-        sctx: &SubtitleContext,
         lctx: &mut layout::LayoutContext<'_>,
-        font_size: I26Dot6,
+        sctx: &SubtitleContext,
         output: &mut Vec<Rect2<FixedL>>,
+        base_style: &ComputedStyle,
+        sc: &StylingContext,
     ) -> Result<(Point2L, layout::inline::InlineContentFragment), layout::InlineLayoutError> {
         let mut fragment = layout::inline::layout(
             lctx,
@@ -126,12 +178,28 @@ impl Event {
                 size: Vec2L::new(sctx.video_width * self.size as f32 / 100, FixedL::MAX),
             },
             &{
-                let mut builder = InlineContentBuilder::new({
-                    let mut style = self.root.base_style.clone();
-                    *style.make_text_align_mut() = self.horizontal_alignment;
-                    style
-                });
-                self.root.append_to(&mut builder.root(), font_size);
+                let root_style = {
+                    let mut result = base_style.clone();
+                    *result.make_text_align_mut() = self.horizontal_alignment;
+                    result
+                };
+                let root_span_style = {
+                    apply_declarations_to(
+                        lctx.log,
+                        root_style.clone(),
+                        &mut sc.declarations_matching(&self.root),
+                        &ComputedStyle::DEFAULT,
+                        None,
+                        sc.logset,
+                    )
+                };
+
+                let mut builder = InlineContentBuilder::new(root_style);
+                {
+                    let mut root_builder = builder.root();
+                    let mut span_builder = root_builder.push_span(root_span_style);
+                    self.root.append_to(lctx.log, &mut span_builder, sc);
+                }
                 builder.finish()
             },
         )?;
@@ -361,88 +429,63 @@ enum Node {
     Element(Element),
 }
 
-#[derive(Debug)]
-struct Element {
-    base_style: ComputedStyle,
-    kind: ElementKind,
-    children: Vec<Node>,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SpanKind {
+    Class,
+    Italic,
+    Bold,
+    Underline,
+    Voice,
+    Language,
+    Ruby,
+    Root,
 }
 
 #[derive(Debug)]
 enum ElementKind {
-    Span,
+    Span(SpanKind),
     Ruby,
     RubyText,
 }
 
-fn convert_node(
-    output: &mut Vec<Node>,
-    parent_style: &ComputedStyle,
-    node: &vtt::Node,
-    mut in_ruby: bool,
-) {
+// TODO: Now that styles are always computed in layout, this struct is only here to be
+//       an owned counterpart to the borrowed `text::InternalNode`.
+//       Perhaps `text::InternalNode` should just be made owned?
+#[derive(Debug)]
+struct Element {
+    kind: ElementKind,
+    id: Option<Box<str>>,
+    /// `.`-separated classes
+    classlist: Box<str>,
+    children: Vec<Node>,
+}
+
+fn convert_node(output: &mut Vec<Node>, node: &vtt::Node, mut in_ruby: bool) {
     match node {
         vtt::Node::Internal(internal) => {
-            let mut style = parent_style.create_derived();
-            match internal.kind {
-                vtt::InternalNodeKind::Italic => {
-                    *style.make_font_slant_mut() = FontSlant::Italic;
-                }
-                vtt::InternalNodeKind::Bold => {
-                    *style.make_font_weight_mut() = I16Dot16::new(700);
-                }
-                vtt::InternalNodeKind::Underline => {
-                    style.text_decoration_line().underline = true;
-                }
-                _ => (),
-            }
-
-            for mut class in internal.classes.iter() {
-                let is_background = match class.strip_prefix("bg_") {
-                    Some(unprefixed) => {
-                        class = unprefixed;
-                        true
-                    }
-                    None => false,
-                };
-
-                let color = match class {
-                    "white" => BGRA8::WHITE,
-                    "lime" => BGRA8::LIME,
-                    "cyan" => BGRA8::CYAN,
-                    "red" => BGRA8::RED,
-                    "yellow" => BGRA8::YELLOW,
-                    "magenta" => BGRA8::MAGENTA,
-                    "blue" => BGRA8::BLUE,
-                    "black" => BGRA8::BLACK,
-                    _ => continue,
-                };
-
-                if is_background {
-                    *style.make_background_color_mut() = Color::Srgb(color);
-                } else {
-                    *style.make_color_mut() = color;
-                }
-            }
-
             let mut result = Element {
-                base_style: style.clone(),
                 kind: match internal.kind {
-                    // NOTE: Based on the wording in https://www.w3.org/TR/webvtt1/#webvtt-cue-ruby-span
-                    //       I assume that nested ruby is not allowed, so we don't accept it.
-                    //       Also nested ruby seems to break current inline layout :) (FIXME)
+                    // TODO: Nested ruby is not currently supported by our layout engine.
                     vtt::InternalNodeKind::Ruby if !in_ruby => {
                         in_ruby = true;
                         ElementKind::Ruby
                     }
                     vtt::InternalNodeKind::RubyText => ElementKind::RubyText,
-                    _ => ElementKind::Span,
+                    vtt::InternalNodeKind::Class => ElementKind::Span(SpanKind::Class),
+                    vtt::InternalNodeKind::Italic => ElementKind::Span(SpanKind::Italic),
+                    vtt::InternalNodeKind::Bold => ElementKind::Span(SpanKind::Bold),
+                    vtt::InternalNodeKind::Underline => ElementKind::Span(SpanKind::Underline),
+                    vtt::InternalNodeKind::Voice { .. } => ElementKind::Span(SpanKind::Voice),
+                    vtt::InternalNodeKind::Language => ElementKind::Span(SpanKind::Language),
+                    vtt::InternalNodeKind::Ruby => ElementKind::Span(SpanKind::Ruby),
                 },
+                id: None,
+                classlist: internal.classes.to_string().into_boxed_str(),
                 children: Vec::new(),
             };
 
             for child in &internal.children {
-                convert_node(&mut result.children, &style, child, in_ruby);
+                convert_node(&mut result.children, child, in_ruby);
             }
 
             output.push(Node::Element(result));
@@ -452,70 +495,184 @@ fn convert_node(
     }
 }
 
-fn convert_text(text: &str, base_style: ComputedStyle) -> Element {
+fn build_tree(cue: vtt::Cue) -> Element {
     let mut result = Vec::new();
 
-    for node in vtt::parse_cue_text(text) {
-        convert_node(&mut result, &base_style, &node, false);
+    for node in vtt::parse_cue_text(cue.text) {
+        convert_node(&mut result, &node, false);
     }
 
     Element {
-        base_style,
-        kind: ElementKind::Span,
+        kind: ElementKind::Span(SpanKind::Root),
+        id: Some(cue.track_identifier.into()),
+        classlist: Box::default(),
         children: result,
     }
 }
 
+// https://www.w3.org/TR/webvtt1/#the-cue-pseudo-element
+impl Element {
+    fn type_(&self) -> Option<&str> {
+        Some(match self.kind {
+            ElementKind::Span(SpanKind::Class) => "c",
+            ElementKind::Span(SpanKind::Italic) => "i",
+            ElementKind::Span(SpanKind::Bold) => "b",
+            ElementKind::Span(SpanKind::Underline) => "u",
+            ElementKind::Span(SpanKind::Voice) => "v",
+            ElementKind::Span(SpanKind::Language) => "lang",
+            ElementKind::Ruby | ElementKind::Span(SpanKind::Ruby) => "ruby",
+            ElementKind::RubyText => "rt",
+            ElementKind::Span(SpanKind::Root) => return None,
+        })
+    }
+
+    fn id(&self) -> Option<&str> {
+        self.id.as_deref()
+    }
+
+    fn classlist(&self) -> impl Iterator<Item = &str> {
+        self.classlist.split('.')
+    }
+}
+
+struct StylingContext<'a> {
+    stylesheets: &'a [Stylesheet],
+    logset: &'a LogOnceSet,
+}
+
+impl StylingContext<'_> {
+    fn declarations_matching(&self, element: &Element) -> impl Iterator<Item = &[Declaration<'_>]> {
+        let all_rules = self.stylesheets.iter().flat_map(|s| s.rules());
+        let mut matching_rules = all_rules
+            .filter(|x| x.selector().matches(element))
+            .collect::<Vec<_>>();
+
+        matching_rules.sort_by_key(|rule| rule.selector().specificity());
+
+        matching_rules.into_iter().map(|rule| rule.declarations())
+    }
+}
+
 impl Node {
-    fn append_to(&self, span_builder: &mut InlineSpanBuilder, font_size: I26Dot6) {
+    fn append_to(
+        &self,
+        log: &LogContext,
+        span_builder: &mut InlineSpanBuilder,
+        sc: &StylingContext,
+    ) {
         match self {
             Node::Text(text) => span_builder.push_text(text),
-            Node::Element(element) => element.append_to(span_builder, font_size),
+            Node::Element(element) => element.append_to(log, span_builder, sc),
         }
     }
 }
 
 impl Element {
-    fn append_to(&self, span_builder: &mut InlineSpanBuilder, font_size: I26Dot6) {
-        let mut style = self.base_style.clone();
-        *style.make_font_size_mut() = font_size;
+    fn apply_default_style_rules(&self, mut style: ComputedStyle) -> ComputedStyle {
+        match self.kind {
+            ElementKind::Span(SpanKind::Italic) => {
+                *style.make_font_slant_mut() = FontSlant::Italic;
+            }
+            ElementKind::Span(SpanKind::Bold) => {
+                *style.make_font_weight_mut() = I16Dot16::new(700);
+            }
+            ElementKind::Span(SpanKind::Underline) => {
+                style.text_decoration_line().underline = true;
+            }
+            ElementKind::RubyText => {
+                *style.make_font_size_mut() = style.font_size() / 2;
+                style
+                    .make_font_feature_settings_mut()
+                    .set(OpenTypeTag::FEAT_RUBY, 1);
+            }
+            _ => (),
+        }
+
+        for mut class in self.classlist.split('.') {
+            let is_background = match class.strip_prefix("bg_") {
+                Some(unprefixed) => {
+                    class = unprefixed;
+                    true
+                }
+                None => false,
+            };
+
+            let color = match class {
+                "white" => BGRA8::WHITE,
+                "lime" => BGRA8::LIME,
+                "cyan" => BGRA8::CYAN,
+                "red" => BGRA8::RED,
+                "yellow" => BGRA8::YELLOW,
+                "magenta" => BGRA8::MAGENTA,
+                "blue" => BGRA8::BLUE,
+                "black" => BGRA8::BLACK,
+                _ => continue,
+            };
+
+            if is_background {
+                *style.make_background_color_mut() = Color::Srgb(color);
+            } else {
+                *style.make_color_mut() = color;
+            }
+        }
+
+        style
+    }
+
+    fn append_to(
+        &self,
+        log: &LogContext,
+        span_builder: &mut InlineSpanBuilder,
+        sc: &StylingContext,
+    ) {
+        let style = apply_declarations_to(
+            log,
+            self.apply_default_style_rules(span_builder.style().create_derived()),
+            &mut sc.declarations_matching(self),
+            span_builder.style(),
+            Some(&WEBVTT_DECLARATION_FILTER),
+            sc.logset,
+        );
 
         match self.kind {
-            ElementKind::Span | ElementKind::RubyText => {
+            ElementKind::Span(_) | ElementKind::RubyText => {
                 let mut builder = span_builder.push_span(style);
                 for child in &self.children {
-                    child.append_to(&mut builder, font_size);
+                    child.append_to(log, &mut builder, sc);
                 }
             }
             ElementKind::Ruby => {
                 let mut builder = span_builder.push_ruby(style.clone());
-                let annotation_font_size = font_size / 2;
-                let base_style = style.create_derived();
-                let annotation_style = {
-                    let mut result = style.create_derived();
-                    *result.make_font_size_mut() = annotation_font_size;
-                    result
-                        .make_font_feature_settings_mut()
-                        .set(OpenTypeTag::FEAT_RUBY, 1);
-                    result
-                };
+                let child_base_style = style.create_derived();
 
-                let mut current_base = builder.push_base(base_style.clone());
+                let mut current_base = builder.push_base(child_base_style.clone());
                 for child in &self.children {
                     match child {
-                        Node::Element(Element {
-                            kind: ElementKind::RubyText,
-                            ..
-                        }) => {
+                        Node::Element(
+                            child_element @ Element {
+                                kind: ElementKind::RubyText,
+                                ..
+                            },
+                        ) => {
                             drop(current_base);
-                            child.append_to(
-                                &mut builder.push_annotation(annotation_style.clone()),
-                                annotation_font_size,
+                            let annotation_style = apply_declarations_to(
+                                log,
+                                self.apply_default_style_rules(child_base_style.clone()),
+                                &mut sc.declarations_matching(child_element),
+                                &style,
+                                Some(&WEBVTT_DECLARATION_FILTER),
+                                sc.logset,
                             );
-                            current_base = builder.push_base(base_style.clone());
+
+                            child.append_to(
+                                log,
+                                &mut builder.push_annotation(annotation_style.clone()),
+                                sc,
+                            );
+                            current_base = builder.push_base(child_base_style.clone());
                         }
                         _ => {
-                            child.append_to(&mut current_base, font_size);
+                            child.append_to(log, &mut current_base, sc);
                         }
                     }
                 }
@@ -527,34 +684,17 @@ impl Element {
 #[derive(Debug)]
 pub struct Subtitles {
     events: Vec<Event>,
+    stylesheets: Vec<Stylesheet>,
 }
 
 pub fn convert(log: &LogContext, captions: vtt::Captions) -> Subtitles {
-    let base_style = {
-        let mut result = ComputedStyle::DEFAULT;
-
-        // The font shorthand property on the (root) list of WebVTT Node Objects must be set to 5vh sans-serif.
-        *result.make_font_family_mut() = rc_static!([rc_static!(str b"sans-serif")]);
-        // The color property on the (root) list of WebVTT Node Objects must be set to rgba(255,255,255,1).
-        *result.make_color_mut() = BGRA8::WHITE;
-        // The background shorthand property on the WebVTT cue background box and on WebVTT Ruby Text Objects must be set to rgba(0,0,0,0.8).
-        *result.make_background_color_mut() = Color::Srgb(BGRA8::new(0, 0, 0, 204));
-        // The white-space property on the (root) list of WebVTT Node Objects must be set to pre-line.
-        *result.make_white_space_collapse_mut() = WhiteSpaceCollapse::PreserveBreaks;
-
-        result
+    let mut subtitles = Subtitles {
+        events: Vec::new(),
+        stylesheets: Vec::new(),
     };
-    let mut subtitles = Subtitles { events: Vec::new() };
 
     let logset = LogOnceSet::new();
     log_once_state!(in logset; region_unsupported);
-
-    if !captions.stylesheets.is_empty() {
-        warn!(
-            log,
-            "WebVTT file makes use of stylesheets which are currently not supported and will be ignored."
-        )
-    }
 
     for cue in captions.cues {
         if cue.region.is_some() && !captions.regions.is_empty() {
@@ -631,8 +771,20 @@ pub fn convert(log: &LogContext, captions: vtt::Captions) -> Subtitles {
             size,
             x: x_position / 100.,
             y: y_position / 100.,
-            root: convert_text(cue.text, base_style.clone()),
+            root: build_tree(cue),
         });
+    }
+
+    for source in captions.stylesheets {
+        let stylesheet = match Stylesheet::parse(log, source.into()) {
+            Ok(t) => t,
+            Err(err) => {
+                warn!(log, "Failed to tokenize a `STYLE` block's content: {err}");
+                continue;
+            }
+        };
+
+        subtitles.stylesheets.push(stylesheet);
     }
 
     subtitles
@@ -693,11 +845,16 @@ impl SubtitleEvent for Event {
 
 pub(crate) struct Layouter {
     subtitles: Rc<Subtitles>,
+    // for deduplicating logs about unrecognized declarations
+    styling_log_set: log::LogOnceSet,
 }
 
 impl Layouter {
     pub fn new(subtitles: Rc<Subtitles>) -> Self {
-        Self { subtitles }
+        Self {
+            subtitles,
+            styling_log_set: log::LogOnceSet::new(),
+        }
     }
 
     pub fn subtitles(&self) -> &Rc<Subtitles> {
@@ -708,17 +865,42 @@ impl Layouter {
         // TODO: This should actually be persisted between frames.
         let mut output = Vec::new();
 
-        // Standard says 5vh, but browser engines use 5vmin.
-        // See https://github.com/w3c/webvtt/issues/529
-        let font_size =
-            pass.sctx.video_height.min(pass.sctx.video_width) * 0.05 / pass.sctx.pixel_scale();
+        let base_style = {
+            let mut result = ComputedStyle::DEFAULT;
+
+            // The font shorthand property on the (root) list of WebVTT Node Objects must be set to 5vh sans-serif.
+            *result.make_font_family_mut() = rc_static!([rc_static!(str b"sans-serif")]);
+            // The color property on the (root) list of WebVTT Node Objects must be set to rgba(255,255,255,1).
+            *result.make_color_mut() = BGRA8::WHITE;
+            // The background shorthand property on the WebVTT cue background box and on WebVTT Ruby Text Objects must be set to rgba(0,0,0,0.8).
+            *result.make_background_color_mut() = Color::Srgb(BGRA8::new(0, 0, 0, 204));
+            // The white-space property on the (root) list of WebVTT Node Objects must be set to pre-line.
+            *result.make_white_space_collapse_mut() = WhiteSpaceCollapse::PreserveBreaks;
+
+            // Standard says 5vh, but browser engines use 5vmin.
+            // See https://github.com/w3c/webvtt/issues/529
+            let font_size =
+                pass.sctx.video_height.min(pass.sctx.video_width) * 0.05 / pass.sctx.pixel_scale();
+            *result.make_font_size_mut() = font_size;
+
+            result
+        };
 
         for event in &self.subtitles.events {
             if !pass.add_event_range(event.range.clone()) {
                 continue;
             }
 
-            let (pos, inline) = event.layout(pass.sctx, pass.lctx, font_size, &mut output)?;
+            let (pos, inline) = event.layout(
+                pass.lctx,
+                pass.sctx,
+                &mut output,
+                &base_style,
+                &StylingContext {
+                    stylesheets: &self.subtitles.stylesheets,
+                    logset: &self.styling_log_set,
+                },
+            )?;
             pass.emit_fragment(pos, BlockContainerFragment::from_inline(inline));
         }
 

--- a/src/vtt/convert/selectors.rs
+++ b/src/vtt/convert/selectors.rs
@@ -1,0 +1,307 @@
+//! Implements parsing and matching of a subset of CSS [Selectors].
+//!
+//! This implementation is specific to WebVTT and has bad error messages
+//! but is reasonably simple.
+//!
+//! [Selectors]: https://drafts.csswg.org/selectors/
+use crate::{
+    csssyn::{
+        buffer::{Cursor, HashTypeFlag},
+        token::{FunctionalNotation, Hash, Ident, Token, Whitespace},
+        ParseError,
+    },
+    vtt::convert::{Element, ElementKind, SpanKind},
+};
+
+#[derive(Debug)]
+pub(super) struct ComplexSelectorUnit {
+    selector: Option<CompoundSelector>,
+    pseudo: Option<PseudoCompoundSelector>,
+}
+
+#[derive(Debug)]
+struct CompoundSelector {
+    type_: Option<TypeSelector>,
+    subclasses: Vec<SubclassSelector>,
+}
+
+#[derive(Debug)]
+struct PseudoCompoundSelector {
+    element: PseudoElementSelector,
+}
+
+#[derive(Debug)]
+enum PseudoElementSelector {
+    Cue(Option<Box<ComplexSelectorUnit>>),
+}
+
+#[derive(Debug)]
+enum TypeSelector {
+    Ident(Box<str>),
+    Universal,
+}
+
+#[derive(Debug)]
+enum SubclassSelector {
+    Id(Box<str>),
+    Class(Box<str>),
+}
+
+fn consume_compound_selector(
+    mut cursor: Cursor,
+) -> Result<(Option<CompoundSelector>, Cursor), ParseError> {
+    let type_ = if let Some((ident, next)) = cursor.take::<Ident>() {
+        cursor = next;
+        Some(TypeSelector::Ident(ident.value().into()))
+    } else if let Some(next) = cursor.next_if(Token![*]) {
+        cursor = next;
+        Some(TypeSelector::Universal)
+    } else {
+        None
+    };
+
+    let mut subclasses = Vec::new();
+    loop {
+        if let Some((hash, next)) = cursor.take::<Hash>() {
+            if hash.type_flag() != HashTypeFlag::Id {
+                return Err(ParseError::new(
+                    hash,
+                    "<id-selector>'s <hash> value must be an identifier",
+                ));
+            }
+
+            cursor = next;
+            subclasses.push(SubclassSelector::Id(hash.value().into()));
+        } else if let Some(next) = cursor.next_if(Token![.]) {
+            let Some((ident, next)) = next.take::<Ident>() else {
+                return Err(ParseError::new(cursor, "invalid class selector"));
+            };
+            cursor = next;
+            subclasses.push(SubclassSelector::Class(ident.value().into()));
+        } else {
+            break;
+        }
+    }
+
+    if type_.is_none() && subclasses.is_empty() {
+        Ok((None, cursor))
+    } else {
+        Ok((Some(CompoundSelector { type_, subclasses }), cursor))
+    }
+}
+
+fn consume_pseudo_element_selector(
+    cursor: Cursor,
+) -> Result<Option<(PseudoElementSelector, Cursor)>, ParseError> {
+    let Some(cursor) = cursor.next_if(Token![:]) else {
+        return Ok(None);
+    };
+    let Some(cursor) = cursor.next_if(Token![:]) else {
+        return Err(ParseError::unexpected(cursor, &[<Token![:]>::name()]));
+    };
+
+    if let Some((ident, cursor)) = cursor.take::<Ident>() {
+        if ident.value().eq_ignore_ascii_case("cue") {
+            return Ok(Some((PseudoElementSelector::Cue(None), cursor)));
+        }
+    } else if let Ok((func, cursor)) = FunctionalNotation::take(cursor) {
+        if func.function().eq_ignore_ascii_case("cue") {
+            return Ok(Some((
+                PseudoElementSelector::Cue(Some(Box::new(parse_complex_selector_unit(
+                    func.content(),
+                )?))),
+                cursor,
+            )));
+        }
+    } else {
+        return Err(ParseError::unexpected(
+            cursor,
+            &[Ident::name(), FunctionalNotation::name()],
+        ));
+    }
+
+    Err(ParseError::new(cursor, "unknown pseudo element"))
+}
+
+fn consume_pseudo_compound_selector(
+    cursor: Cursor,
+) -> Result<Option<(PseudoCompoundSelector, Cursor)>, ParseError> {
+    match consume_pseudo_element_selector(cursor) {
+        Ok(Some((element, cursor))) => Ok(Some((PseudoCompoundSelector { element }, cursor))),
+        Ok(None) => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
+pub fn parse_complex_selector_unit(mut cursor: Cursor) -> Result<ComplexSelectorUnit, ParseError> {
+    cursor = cursor.skip(Whitespace);
+
+    let compound;
+    (compound, cursor) = consume_compound_selector(cursor)?;
+
+    let pseudo = match consume_pseudo_compound_selector(cursor)? {
+        Some((pseudo, next)) => {
+            cursor = next;
+            Some(pseudo)
+        }
+        None => None,
+    };
+
+    if compound.is_none() && pseudo.is_none() {
+        return Err(ParseError::new(cursor, "invalid complex selector unit"));
+    }
+
+    cursor = cursor.skip(Whitespace);
+
+    if !cursor.eof() {
+        return Err(ParseError::new(cursor, "unexpected tokens"));
+    }
+
+    Ok(ComplexSelectorUnit {
+        selector: compound,
+        pseudo,
+    })
+}
+
+impl TypeSelector {
+    fn matches_anonymous(&self) -> bool {
+        match self {
+            TypeSelector::Ident(_) => false,
+            TypeSelector::Universal => true,
+        }
+    }
+
+    fn matches_in_cue(&self, element: &Element) -> bool {
+        match self {
+            TypeSelector::Ident(type_) => element.type_().is_some_and(|t| t == &**type_),
+            TypeSelector::Universal => true,
+        }
+    }
+}
+
+impl SubclassSelector {
+    fn matches_anonymous(&self) -> bool {
+        match self {
+            SubclassSelector::Id(_) => false,
+            SubclassSelector::Class(_) => false,
+        }
+    }
+
+    fn matches_in_cue(&self, element: &Element) -> bool {
+        match self {
+            SubclassSelector::Id(id) => element.id().is_some_and(|i| i == &**id),
+            SubclassSelector::Class(class) => element.classlist().any(|c| c == &**class),
+        }
+    }
+}
+
+impl CompoundSelector {
+    fn matches_anonymous(&self) -> bool {
+        self.type_.as_ref().is_none_or(|s| s.matches_anonymous())
+            && self.subclasses.iter().all(|s| s.matches_anonymous())
+    }
+
+    fn matches_in_cue(&self, element: &Element) -> bool {
+        self.type_
+            .as_ref()
+            .is_none_or(|s| s.matches_in_cue(element))
+            && self.subclasses.iter().all(|s| s.matches_in_cue(element))
+    }
+}
+
+impl ComplexSelectorUnit {
+    fn matches_in_cue(&self, element: &Element) -> bool {
+        self.pseudo.is_none()
+            && self
+                .selector
+                .as_ref()
+                .is_none_or(|x| x.matches_in_cue(element))
+    }
+}
+
+impl ComplexSelectorUnit {
+    pub(super) fn matches(&self, cue_element: &Element) -> bool {
+        self.selector.as_ref().is_none_or(|s| s.matches_anonymous())
+            && match self.pseudo.as_ref() {
+                Some(PseudoCompoundSelector {
+                    element: PseudoElementSelector::Cue(cue_selector),
+                }) => match cue_selector {
+                    Some(selector) => selector.matches_in_cue(cue_element),
+                    None => matches!(cue_element.kind, ElementKind::Span(SpanKind::Root)),
+                },
+                None => false,
+            }
+    }
+}
+
+#[derive(Default, Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
+pub(super) struct Specificity {
+    a: u16,
+    b: u16,
+    c: u16,
+}
+
+impl Specificity {
+    const ZERO: Self = Self { a: 0, b: 0, c: 0 };
+}
+
+impl std::ops::Add for Specificity {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self {
+            a: self.a + rhs.a,
+            b: self.b + rhs.b,
+            c: self.c + rhs.c,
+        }
+    }
+}
+
+impl std::ops::AddAssign for Specificity {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
+impl CompoundSelector {
+    // https://drafts.csswg.org/selectors/#specificity-rules
+    fn specificity(&self) -> Specificity {
+        let mut result = Specificity::ZERO;
+
+        match self.type_ {
+            Some(TypeSelector::Ident(_)) => result.c += 1,
+            Some(TypeSelector::Universal) | None => (),
+        }
+
+        for s in &self.subclasses {
+            match s {
+                SubclassSelector::Id(_) => result.a += 1,
+                SubclassSelector::Class(_) => result.b += 1,
+            }
+        }
+        result
+    }
+}
+
+impl ComplexSelectorUnit {
+    pub(super) fn specificity(&self) -> Specificity {
+        let mut result = self
+            .selector
+            .as_ref()
+            // TODO: map_or_default (MSRV: 1.98) (below too)
+            .map_or(Specificity::ZERO, CompoundSelector::specificity);
+
+        if let Some(pseudo) = self.pseudo.as_ref() {
+            result.c += 1;
+            match &pseudo.element {
+                PseudoElementSelector::Cue(inner) => {
+                    result += inner
+                        .as_ref()
+                        .map_or(Specificity::ZERO, |s| s.specificity());
+                }
+            }
+        }
+
+        result
+    }
+}

--- a/src/vtt/convert/selectors.rs
+++ b/src/vtt/convert/selectors.rs
@@ -13,35 +13,35 @@ use crate::{
     vtt::convert::{Element, ElementKind, SpanKind},
 };
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(super) struct ComplexSelectorUnit {
     selector: Option<CompoundSelector>,
     pseudo: Option<PseudoCompoundSelector>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 struct CompoundSelector {
     type_: Option<TypeSelector>,
     subclasses: Vec<SubclassSelector>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 struct PseudoCompoundSelector {
     element: PseudoElementSelector,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 enum PseudoElementSelector {
     Cue(Option<Box<ComplexSelectorUnit>>),
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 enum TypeSelector {
     Ident(Box<str>),
     Universal,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 enum SubclassSelector {
     Id(Box<str>),
     Class(Box<str>),
@@ -303,5 +303,141 @@ impl ComplexSelectorUnit {
         }
 
         result
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::csssyn::TokenBuffer;
+
+    #[track_caller]
+    fn test_parse(text: &str, expected: ComplexSelectorUnit, expected_specificity: Specificity) {
+        let buffer = TokenBuffer::from_source(text).unwrap();
+        let result = parse_complex_selector_unit(buffer.start()).unwrap();
+
+        assert_eq!(result, expected);
+        assert_eq!(result.specificity(), expected_specificity);
+    }
+
+    #[test]
+    fn parse_compound() {
+        test_parse(
+            ".abc",
+            ComplexSelectorUnit {
+                selector: Some(CompoundSelector {
+                    type_: None,
+                    subclasses: vec![SubclassSelector::Class("abc".into())],
+                }),
+                pseudo: None,
+            },
+            Specificity { a: 0, b: 1, c: 0 },
+        );
+
+        test_parse(
+            "type#id.cl1.cl2",
+            ComplexSelectorUnit {
+                selector: Some(CompoundSelector {
+                    type_: Some(TypeSelector::Ident("type".into())),
+                    subclasses: vec![
+                        SubclassSelector::Id("id".into()),
+                        SubclassSelector::Class("cl1".into()),
+                        SubclassSelector::Class("cl2".into()),
+                    ],
+                }),
+                pseudo: None,
+            },
+            Specificity { a: 1, b: 2, c: 1 },
+        );
+
+        test_parse(
+            "*.cl1#id",
+            ComplexSelectorUnit {
+                selector: Some(CompoundSelector {
+                    type_: Some(TypeSelector::Universal),
+                    subclasses: vec![
+                        SubclassSelector::Class("cl1".into()),
+                        SubclassSelector::Id("id".into()),
+                    ],
+                }),
+                pseudo: None,
+            },
+            Specificity { a: 1, b: 1, c: 0 },
+        );
+    }
+
+    #[test]
+    fn parse_cue_pseudo_element() {
+        test_parse(
+            "::cue",
+            ComplexSelectorUnit {
+                selector: None,
+                pseudo: Some(PseudoCompoundSelector {
+                    element: PseudoElementSelector::Cue(None),
+                }),
+            },
+            Specificity { a: 0, b: 0, c: 1 },
+        );
+
+        test_parse(
+            "type#id.abc::cue",
+            ComplexSelectorUnit {
+                selector: Some(CompoundSelector {
+                    type_: Some(TypeSelector::Ident("type".into())),
+                    subclasses: vec![
+                        SubclassSelector::Id("id".into()),
+                        SubclassSelector::Class("abc".into()),
+                    ],
+                }),
+                pseudo: Some(PseudoCompoundSelector {
+                    element: PseudoElementSelector::Cue(None),
+                }),
+            },
+            Specificity { a: 1, b: 1, c: 2 },
+        );
+
+        test_parse(
+            "::cue(.abc)",
+            ComplexSelectorUnit {
+                selector: None,
+                pseudo: Some(PseudoCompoundSelector {
+                    element: PseudoElementSelector::Cue(Some(Box::new(ComplexSelectorUnit {
+                        selector: Some(CompoundSelector {
+                            type_: None,
+                            subclasses: vec![SubclassSelector::Class("abc".into())],
+                        }),
+                        pseudo: None,
+                    }))),
+                }),
+            },
+            Specificity { a: 0, b: 1, c: 1 },
+        );
+
+        test_parse(
+            "::cue(.abc::cue(def))",
+            ComplexSelectorUnit {
+                selector: None,
+                pseudo: Some(PseudoCompoundSelector {
+                    element: PseudoElementSelector::Cue(Some(Box::new(ComplexSelectorUnit {
+                        selector: Some(CompoundSelector {
+                            type_: None,
+                            subclasses: vec![SubclassSelector::Class("abc".into())],
+                        }),
+                        pseudo: Some(PseudoCompoundSelector {
+                            element: PseudoElementSelector::Cue(Some(Box::new(
+                                ComplexSelectorUnit {
+                                    selector: Some(CompoundSelector {
+                                        type_: Some(TypeSelector::Ident("def".into())),
+                                        subclasses: Vec::new(),
+                                    }),
+                                    pseudo: None,
+                                },
+                            ))),
+                        }),
+                    }))),
+                }),
+            },
+            Specificity { a: 0, b: 1, c: 3 },
+        );
     }
 }

--- a/src/vtt/convert/stylesheet.rs
+++ b/src/vtt/convert/stylesheet.rs
@@ -1,0 +1,113 @@
+use log::{warn, LogContext};
+
+use super::selectors::{self, ComplexSelectorUnit};
+use crate::csssyn::{
+    self,
+    algorithms::{Declaration, QualifiedRule, Rule},
+    buffer::{BufferTokenizationError, Cursor},
+    token::Whitespace,
+    Spanned, TokenBuffer,
+};
+
+#[derive(Debug)]
+pub(super) struct StyleRule<'a> {
+    selector: ComplexSelectorUnit,
+    declarations: Vec<Declaration<'a>>,
+}
+
+impl<'a> StyleRule<'a> {
+    fn parse(log: &LogContext, rule: QualifiedRule<'a>) -> Option<Self> {
+        let selector = match selectors::parse_complex_selector_unit(rule.prelude) {
+            Ok(s) => s,
+            Err(err) => {
+                warn!(
+                    log,
+                    "Failed to parse selector `{}`: {err}",
+                    rule.prelude
+                        .skip(Whitespace)
+                        .skip_back(Whitespace)
+                        .scope_source()
+                );
+                return None;
+            }
+        };
+
+        let mut declarations = Vec::new();
+        for item in rule.content.parse() {
+            match item {
+                csssyn::algorithms::BlockItem::Rule(Rule::Qualified(nested)) => {
+                    warn!(
+                        log,
+                        "Encountered unsupported nested qualified rule at byte {}",
+                        nested.prelude.span().start,
+                    );
+                }
+                csssyn::algorithms::BlockItem::Declaration(declaration) => {
+                    declarations.push(declaration);
+                }
+            }
+        }
+
+        Some(Self {
+            selector,
+            declarations,
+        })
+    }
+
+    pub(super) fn selector(&self) -> &ComplexSelectorUnit {
+        &self.selector
+    }
+
+    pub(super) fn declarations(&self) -> &[Declaration<'a>] {
+        &self.declarations
+    }
+}
+
+impl<'a> StylesheetInner<'a> {
+    fn parse(log: &LogContext, cursor: Cursor<'a>) -> Self {
+        let mut result = Self { rules: Vec::new() };
+
+        for Rule::Qualified(rule) in csssyn::algorithms::consume_a_stylesheets_contents(cursor) {
+            result.rules.extend(StyleRule::parse(log, rule));
+        }
+
+        result
+    }
+}
+
+#[derive(Debug)]
+struct StylesheetInner<'a> {
+    rules: Vec<StyleRule<'a>>,
+}
+
+// self-referential
+pub(super) struct Stylesheet {
+    inner: StylesheetInner<'static>,
+    _tokens: TokenBuffer<'static>,
+    _source: Box<str>,
+}
+
+impl std::fmt::Debug for Stylesheet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&self.inner, f)
+    }
+}
+
+impl Stylesheet {
+    pub(super) fn parse(
+        log: &LogContext,
+        source: Box<str>,
+    ) -> Result<Self, BufferTokenizationError> {
+        let tokens = TokenBuffer::from_source(&source)?;
+
+        Ok(Stylesheet {
+            inner: unsafe { std::mem::transmute(StylesheetInner::parse(log, tokens.start())) },
+            _tokens: unsafe { std::mem::transmute(tokens) },
+            _source: source,
+        })
+    }
+
+    pub(super) fn rules(&self) -> &[StyleRule<'_>] {
+        &self.inner.rules
+    }
+}

--- a/src/vtt/parse.rs
+++ b/src/vtt/parse.rs
@@ -631,7 +631,7 @@ fn collect_block<'a>(
         Some(Block::Cue(cue))
     } else if let Some(()) = stylesheet {
         // Otherwise, if stylesheet is not null, then Parse a stylesheet from buffer. If it returned a list of rules, assign the list as stylesheet’s CSS rules; otherwise, set stylesheet’s CSS rules to an empty list. Finally, return stylesheet.
-        // NOTE: Currently stylesheets are not supported so they're just passed through as is.
+        // NOTE: These are parsed later.
         Some(Block::Stylesheet(buffer))
     } else if let Some(mut region) = region {
         // Otherwise, if region is not null, then collect WebVTT region settings from buffer using region for the results. Construct a WebVTT Region Object from region, and return it.

--- a/src/vtt/parse/text/tokenizer.rs
+++ b/src/vtt/parse/text/tokenizer.rs
@@ -225,6 +225,18 @@ impl<'a> ClassList<'a> {
     pub fn iter(&self) -> impl Iterator<Item = &'a str> {
         self.0.split('.').filter(|class| !class.is_empty())
     }
+
+    #[allow(clippy::inherent_to_string)]
+    pub fn to_string(self) -> String {
+        let mut result = String::with_capacity(self.0.len());
+        for class in self.iter() {
+            if !result.is_empty() {
+                result.push('.');
+            }
+            result.push_str(class);
+        }
+        result
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
While suffering through `css-writing-modes` I decided to implement something "easier" so this is now a thing.

TODO:
- [x] Write some selector parsing tests

More selectors and the `:future`/`:past` pseudo-classes can be added later.