### PR TITLE
Update flake nixpkgs input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767320940,
-        "narHash": "sha256-/qDJCJZbthDK0YL0PkOg8FqFwgHdp3HN3HCr1mWhFtM=",
+        "lastModified": 1788775869,
+        "narHash": "sha256-JRf1lSypbvKj6AzUZHpUA6YC1DirVuitZWOnRwcm+Ww=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "47c0329d02b850cfc72505daa7c7462ee0c5a0df",
+        "rev": "58973d74f1893afe13f5902919803a0e99da0ca4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Should fix nix CI.

http://github.com/nixOS/nixpkgs/commit/e37f43a408ef2968c97237b857fc7b3e7b8bdc18

(crates.io API now gets you a 403 if your user-agent contains "curl/X.Y.Z" or smth but `static.crates.io`  does not do this)